### PR TITLE
docs: update interconnections SVG with all 21 repos

### DIFF
--- a/assets/images/interconnections.svg
+++ b/assets/images/interconnections.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 860 580" width="860" height="580">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 860 680" width="860" height="680">
   <defs>
     <style>
       .page-bg { fill: #ffffff; }
@@ -34,79 +34,152 @@
     </marker>
   </defs>
 
-  <rect class="page-bg" width="860" height="580" rx="8"/>
+  <rect class="page-bg" width="860" height="680" rx="8"/>
   <text class="title" x="430" y="24" text-anchor="middle">Repo Interconnections</text>
 
-  <!-- ===== Nodes ===== -->
+  <!-- ===== Row 1: Research (y=45) ===== -->
+  <!-- coding-agents-research centered, feeds into row 2 -->
 
-  <!-- Row 1: Evaluation layer -->
+  <a xlink:href="https://github.com/qte77/coding-agents-research">
+    <rect class="box" x="343" y="45" width="175" height="48" rx="5"/>
+    <text class="repo-name" x="430" y="65" text-anchor="middle">coding-agents-research</text>
+    <text class="repo-desc" x="430" y="80" text-anchor="middle">CC field research</text>
+  </a>
+
+  <!-- ===== Row 2: Evaluation (y=145) — 6 boxes, w=130, gap=10 ===== -->
+
   <a xlink:href="https://github.com/qte77/Agents-eval">
-    <rect class="box" x="30" y="50" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="118" y="70" text-anchor="middle">Agents-eval</text>
-    <text class="repo-desc" x="118" y="85" text-anchor="middle">3-tier MAS evaluation</text>
+    <rect class="box" x="15" y="145" width="130" height="48" rx="5"/>
+    <text class="repo-name" x="80" y="165" text-anchor="middle">Agents-eval</text>
+    <text class="repo-desc" x="80" y="180" text-anchor="middle">3-tier MAS evaluation</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/RDI-AgentBeats-MAS-GraphJudge">
+    <rect class="box" x="155" y="145" width="130" height="48" rx="5"/>
+    <text class="repo-name" x="220" y="165" text-anchor="middle">MAS-GraphJudge</text>
+    <text class="repo-desc" x="220" y="180" text-anchor="middle">graph benchmarking</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/RDI-AgentBeats-TestBehaveAlign">
+    <rect class="box" x="295" y="145" width="130" height="48" rx="5"/>
+    <text class="repo-name" x="360" y="165" text-anchor="middle">TestBehaveAlign</text>
+    <text class="repo-desc" x="360" y="180" text-anchor="middle">TDD/BDD test quality</text>
+  </a>
+
+  <a xlink:href="https://github.com/pat-tax/RDI-AgentBeats-TheBulletproofProtocol">
+    <rect class="box" x="435" y="145" width="130" height="48" rx="5" stroke-dasharray="4 2"/>
+    <text class="repo-name" x="500" y="165" text-anchor="middle">BulletproofProtocol*</text>
+    <text class="repo-desc" x="500" y="180" text-anchor="middle">adversarial R&amp;D audit</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/coding-agent-eval">
-    <rect class="box" x="240" y="50" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="328" y="70" text-anchor="middle">coding-agent-eval</text>
-    <text class="repo-desc" x="328" y="85" text-anchor="middle">CC evaluation harness</text>
+    <rect class="box" x="575" y="145" width="130" height="48" rx="5"/>
+    <text class="repo-name" x="640" y="165" text-anchor="middle">coding-agent-eval</text>
+    <text class="repo-desc" x="640" y="180" text-anchor="middle">CC evaluation harness</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/multi-tasking-quality-benchmark">
-    <rect class="box" x="450" y="50" width="195" height="48" rx="5"/>
-    <text class="repo-name" x="548" y="70" text-anchor="middle">multi-tasking-quality</text>
-    <text class="repo-desc" x="548" y="85" text-anchor="middle">WakaTime quality correlation</text>
+    <rect class="box" x="715" y="145" width="130" height="48" rx="5"/>
+    <text class="repo-name" x="780" y="165" text-anchor="middle">multi-tasking-quality</text>
+    <text class="repo-desc" x="780" y="180" text-anchor="middle">WakaTime correlation</text>
   </a>
 
-  <a xlink:href="https://github.com/qte77/coding-agents-research">
-    <rect class="box" x="670" y="50" width="165" height="48" rx="5"/>
-    <text class="repo-name" x="753" y="70" text-anchor="middle">coding-agents-research</text>
-    <text class="repo-desc" x="753" y="85" text-anchor="middle">CC field research</text>
-  </a>
+  <!-- ===== Row 3: Tooling (y=255) — 3 boxes, w=175, gap=20 ===== -->
 
-  <!-- Row 2: Tooling layer -->
   <a xlink:href="https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template">
-    <rect class="box" x="30" y="190" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="118" y="210" text-anchor="middle">ralph-loop template</text>
-    <text class="repo-desc" x="118" y="225" text-anchor="middle">autonomous dev loop</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/cc-recursive-team-mode">
-    <rect class="box" x="240" y="190" width="195" height="48" rx="5"/>
-    <text class="repo-name" x="338" y="210" text-anchor="middle">cc-recursive-team-mode</text>
-    <text class="repo-desc" x="338" y="225" text-anchor="middle">recursive CC subprocess</text>
+    <rect class="box" x="148" y="255" width="175" height="48" rx="5"/>
+    <text class="repo-name" x="235" y="275" text-anchor="middle">ralph-loop template</text>
+    <text class="repo-desc" x="235" y="290" text-anchor="middle">autonomous dev loop</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/claude-code-utils-plugin">
-    <rect class="box" x="470" y="190" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="558" y="210" text-anchor="middle">cc-utils-plugin</text>
-    <text class="repo-desc" x="558" y="225" text-anchor="middle">plugins &amp; skills</text>
+    <rect class="box" x="343" y="255" width="175" height="48" rx="5"/>
+    <text class="repo-name" x="430" y="275" text-anchor="middle">cc-utils-plugin</text>
+    <text class="repo-desc" x="430" y="290" text-anchor="middle">plugins &amp; skills</text>
   </a>
 
-  <!-- Row 3: Orchestration layer -->
+  <a xlink:href="https://github.com/qte77/cc-recursive-team-mode">
+    <rect class="box" x="538" y="255" width="175" height="48" rx="5"/>
+    <text class="repo-name" x="625" y="275" text-anchor="middle">cc-recursive-team</text>
+    <text class="repo-desc" x="625" y="290" text-anchor="middle">CC subprocess wrapper</text>
+  </a>
+
+  <!-- ===== Row 4: Orchestration + Apps (y=365) — 4 boxes, w=175, gap=15 ===== -->
+
+  <a xlink:href="https://github.com/qte77/agentic-market-research-to-gtm">
+    <rect class="box" x="58" y="365" width="175" height="48" rx="5"/>
+    <text class="repo-name" x="145" y="385" text-anchor="middle">market-research-to-gtm</text>
+    <text class="repo-desc" x="145" y="400" text-anchor="middle">AI market research</text>
+  </a>
+
   <a xlink:href="https://github.com/qte77/polyforge">
-    <rect class="box" x="240" y="330" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="328" y="350" text-anchor="middle">polyforge</text>
-    <text class="repo-desc" x="328" y="365" text-anchor="middle">multi-repo orchestration</text>
+    <rect class="box" x="248" y="365" width="175" height="48" rx="5"/>
+    <text class="repo-name" x="335" y="385" text-anchor="middle">polyforge</text>
+    <text class="repo-desc" x="335" y="400" text-anchor="middle">multi-repo orchestration</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/CABIO-test">
-    <rect class="box" x="470" y="330" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="558" y="350" text-anchor="middle">CABIO-test</text>
-    <text class="repo-desc" x="558" y="365" text-anchor="middle">business workflows</text>
+    <rect class="box" x="438" y="365" width="175" height="48" rx="5"/>
+    <text class="repo-name" x="525" y="385" text-anchor="middle">CABIO-test</text>
+    <text class="repo-desc" x="525" y="400" text-anchor="middle">business workflows</text>
   </a>
 
-  <!-- Row 4: Applications -->
-  <a xlink:href="https://github.com/qte77/agentic-market-research-to-gtm">
-    <rect class="box" x="80" y="450" width="200" height="48" rx="5"/>
-    <text class="repo-name" x="180" y="470" text-anchor="middle">market-research-to-gtm</text>
-    <text class="repo-desc" x="180" y="485" text-anchor="middle">AI market research</text>
+  <a xlink:href="https://github.com/qte77/agentic-codebase-to-scientific-report">
+    <rect class="box" x="628" y="365" width="175" height="48" rx="5"/>
+    <text class="repo-name" x="715" y="385" text-anchor="middle">codebase-to-report</text>
+    <text class="repo-desc" x="715" y="400" text-anchor="middle">scientific report gen</text>
+  </a>
+
+  <!-- ===== Row 5: ML Foundations + Infra (y=465) — 3 boxes, w=175, gap=30 ===== -->
+
+  <a xlink:href="https://github.com/qte77/App-BERT-Benchmark">
+    <rect class="box" x="138" y="465" width="175" height="48" rx="5"/>
+    <text class="repo-name" x="225" y="485" text-anchor="middle">App-BERT-Benchmark</text>
+    <text class="repo-desc" x="225" y="500" text-anchor="middle">BERT config benchmarks</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/HybridRAG-eval">
+    <rect class="box" x="343" y="465" width="175" height="48" rx="5"/>
+    <text class="repo-name" x="430" y="485" text-anchor="middle">HybridRAG-eval</text>
+    <text class="repo-desc" x="430" y="500" text-anchor="middle">RAG evaluation</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/dotfiles">
-    <rect class="box" x="560" y="450" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="648" y="470" text-anchor="middle">dotfiles</text>
-    <text class="repo-desc" x="648" y="485" text-anchor="middle">dev environment config</text>
+    <rect class="box" x="548" y="465" width="175" height="48" rx="5"/>
+    <text class="repo-name" x="635" y="485" text-anchor="middle">dotfiles</text>
+    <text class="repo-desc" x="635" y="500" text-anchor="middle">dev environment config</text>
+  </a>
+
+  <!-- ===== Row 6: GitHub Actions (y=555) — 5 boxes, w=134, gap=14 ===== -->
+
+  <a xlink:href="https://github.com/qte77/gha-ai-changelog">
+    <rect class="box" x="77" y="555" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="144" y="575" text-anchor="middle">ai-changelog</text>
+    <text class="repo-desc" x="144" y="590" text-anchor="middle">AI-powered changelogs</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/gha-contribution-ascii">
+    <rect class="box" x="225" y="555" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="292" y="575" text-anchor="middle">contribution-ascii</text>
+    <text class="repo-desc" x="292" y="590" text-anchor="middle">contribution graph art</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/gha-dirtree-to-readme">
+    <rect class="box" x="373" y="555" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="440" y="575" text-anchor="middle">dirtree-to-readme</text>
+    <text class="repo-desc" x="440" y="590" text-anchor="middle">dir tree to README</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/gha-arxiv-stats-action">
+    <rect class="box" x="521" y="555" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="588" y="575" text-anchor="middle">arxiv-stats-action</text>
+    <text class="repo-desc" x="588" y="590" text-anchor="middle">arXiv daily paper stats</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/gha-cross-repo-issue-sync">
+    <rect class="box" x="669" y="555" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="736" y="575" text-anchor="middle">cross-repo-issue-sync</text>
+    <text class="repo-desc" x="736" y="590" text-anchor="middle">issue synchronization</text>
   </a>
 
   <!-- ===== Arrows ===== -->
@@ -117,57 +190,59 @@
   <!-- Purple: feeds research into -->
 
   <!-- 1. Agents-eval → ralph-loop (submodule) -->
-  <path d="M 118,98 L 118,190" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
+  <!-- From Agents-eval bottom (80,193) to ralph-loop top (235,255) — diagonal, open space -->
+  <path d="M 80,193 L 235,255" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
 
   <!-- 2. Agents-eval → cc-utils-plugin (uses) -->
-  <path d="M 195,98 C 300,140 440,160 480,190" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
+  <!-- From Agents-eval bottom-right (120,193) curving to cc-utils-plugin top (430,255) — open space between R2 and R3 -->
+  <path d="M 120,193 C 250,225 370,245 430,255" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
 
-  <!-- 3. coding-agent-eval → cc-recursive-team-mode (depends on) -->
-  <path d="M 328,98 L 338,190" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
+  <!-- 3. coding-agent-eval → cc-recursive-team (depends on) -->
+  <!-- Near vertical from (640,193) to (625,255) -->
+  <path d="M 640,193 L 625,255" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
 
   <!-- 4. coding-agent-eval → coding-agents-research (submodule) -->
-  <path d="M 415,62 L 670,62" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
+  <!-- From coding-agent-eval top (610,145) curving up-left to research bottom-right (490,93) -->
+  <path d="M 610,145 C 570,120 520,100 490,93" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
 
-  <!-- 5. coding-agents-research → cc-recursive-team-mode (feeds research) -->
-  <path d="M 700,98 C 620,150 460,170 430,190" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
+  <!-- 5. ralph → cc-utils-plugin (uses skills) -->
+  <!-- Short horizontal right from (323,279) to (343,279) -->
+  <path d="M 323,279 L 343,279" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
 
   <!-- 6. coding-agents-research → coding-agent-eval (feeds research) -->
-  <path d="M 670,86 C 560,100 450,90 415,80" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
+  <!-- From research bottom-right (490,93) curving right-down to coding-agent-eval top (660,145) -->
+  <path d="M 490,93 C 560,110 620,130 660,145" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
 
   <!-- 7. coding-agents-research → multi-tasking-quality (feeds research) -->
-  <path d="M 670,74 L 645,74" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
+  <!-- From research right (518,70) curving far right to multi-tasking top (780,145) -->
+  <path d="M 518,70 C 620,70 740,110 780,145" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
 
-  <!-- 8. coding-agents-research → cc-utils-plugin (feeds research) -->
-  <path d="M 720,98 C 680,150 620,170 620,190" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
+  <!-- 8. ralph → polyforge (runs inside) -->
+  <!-- From ralph bottom (235,303) to polyforge top (335,365) — diagonal, open space -->
+  <path d="M 235,303 C 260,335 310,355 335,365" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
 
-  <!-- 9. ralph → cc-utils-plugin (uses skills) -->
-  <path d="M 205,214 L 470,214" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
+  <!-- 9. CABIO → polyforge (runs inside) -->
+  <!-- Short horizontal left from CABIO left (438,389) to polyforge right (423,389) -->
+  <path d="M 438,389 L 423,389" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
 
-  <!-- 10. ralph → polyforge (runs inside) -->
-  <path d="M 140,238 C 170,290 250,310 270,330" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
+  <!-- 10. market-research → polyforge (runs inside) -->
+  <!-- Short horizontal right from market right (233,389) to polyforge left (248,389) -->
+  <path d="M 233,389 L 248,389" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
 
-  <!-- 11. CABIO → polyforge (runs inside) -->
-  <path d="M 470,354 L 415,354" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
-
-  <!-- 12. ralph → CABIO (creates/updates) -->
-  <path d="M 205,228 C 310,280 430,300 510,330" fill="none" stroke="#d29922" stroke-width="1.5" marker-end="url(#a-orange)"/>
-
-  <!-- 13. market-research → polyforge (runs inside) -->
-  <path d="M 230,450 C 270,415 300,390 310,378" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
-
-  <!-- 14. dotfiles → all devcontainers (used by) -->
-  <path d="M 600,450 C 530,410 430,390 380,378" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
+  <!-- 11. ralph → CABIO (creates/updates) -->
+  <!-- From ralph bottom-right (280,303) curving right-down to CABIO top (525,365) — open space -->
+  <path d="M 280,303 C 350,335 460,355 525,365" fill="none" stroke="#d29922" stroke-width="1.5" marker-end="url(#a-orange)"/>
 
   <!-- ===== Legend ===== -->
-  <line x1="120" y1="555" x2="150" y2="555" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
-  <text class="legend-label" x="158" y="559">uses / depends on</text>
+  <line x1="120" y1="650" x2="150" y2="650" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
+  <text class="legend-label" x="158" y="654">uses / depends on</text>
 
-  <line x1="300" y1="555" x2="330" y2="555" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
-  <text class="legend-label" x="338" y="559">runs inside</text>
+  <line x1="300" y1="650" x2="330" y2="650" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
+  <text class="legend-label" x="338" y="654">runs inside</text>
 
-  <line x1="440" y1="555" x2="470" y2="555" stroke="#d29922" stroke-width="1.5" marker-end="url(#a-orange)"/>
-  <text class="legend-label" x="478" y="559">creates / updates</text>
+  <line x1="440" y1="650" x2="470" y2="650" stroke="#d29922" stroke-width="1.5" marker-end="url(#a-orange)"/>
+  <text class="legend-label" x="478" y="654">creates / updates</text>
 
-  <line x1="600" y1="555" x2="630" y2="555" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
-  <text class="legend-label" x="638" y="559">feeds research</text>
+  <line x1="600" y1="650" x2="630" y2="650" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
+  <text class="legend-label" x="638" y="654">feeds research</text>
 </svg>


### PR DESCRIPTION
## Summary

- Update interconnections SVG to match all repos from architecture.svg
- 6-row layout: Research → Evaluation → Tooling → Orchestration/Apps → ML/Infra → GHAs
- 11 connection arrows (5 blue, 3 green, 1 orange, 2 purple)
- All arrows routed through gaps between rows — no box crossings

## Layout

| Row | Repos |
|-----|-------|
| Research | coding-agents-research |
| Evaluation | Agents-eval, MAS-GraphJudge, TestBehaveAlign, BulletproofProtocol*, coding-agent-eval, multi-tasking-quality |
| Tooling | ralph-loop, cc-utils-plugin, cc-recursive-team |
| Orchestration/Apps | market-research-to-gtm, polyforge, CABIO-test, codebase-to-report |
| ML/Infra | App-BERT-Benchmark, HybridRAG-eval, dotfiles |
| GitHub Actions | ai-changelog, contribution-ascii, dirtree-to-readme, arxiv-stats, cross-repo-issue-sync |

Generated with Claude <noreply@anthropic.com>