### PR TITLE
docs: update architecture SVG + redesign interconnections for agentic lifecycle

### DIFF
--- a/assets/images/architecture.svg
+++ b/assets/images/architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 900 596" width="900" height="596">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 900 518" width="900" height="518">
   <defs>
     <style>
       /* Light mode (default) */
@@ -28,7 +28,7 @@
   </defs>
 
   <!-- Page background -->
-  <rect class="page-bg" width="900" height="596" rx="8"/>
+  <rect class="page-bg" width="900" height="518" rx="8"/>
 
   <!-- Title -->
   <text class="title" x="450" y="24" text-anchor="middle">qte77 — Project Ecosystem</text>
@@ -58,36 +58,29 @@
     <text class="repo-desc" x="700" y="90" text-anchor="middle">scientific report gen</text>
   </a>
 
-  <!-- ===== Layer 2: Agentic Development Engine (4 boxes, w=180, gap=20, start=60) ===== -->
+  <!-- ===== Layer 2: Agentic Development Engine (3 boxes, w=220, gap=30, start=90) ===== -->
   <rect class="layer-bg" x="10" y="118" width="880" height="74" rx="6"/>
   <text class="layer-label" x="20" y="132">AGENTIC DEVELOPMENT ENGINE</text>
 
   <a xlink:href="https://github.com/qte77/polyforge">
     <title>polyforge — Polyrepo dev forge for parallel AI agent workflows across multiple repositories</title>
-    <rect class="box" x="60" y="136" width="180" height="48" rx="5"/>
-    <text class="repo-name" x="150" y="155" text-anchor="middle">polyforge</text>
-    <text class="repo-desc" x="150" y="170" text-anchor="middle">multi-repo orchestration</text>
+    <rect class="box" x="90" y="136" width="220" height="48" rx="5"/>
+    <text class="repo-name" x="200" y="155" text-anchor="middle">polyforge</text>
+    <text class="repo-desc" x="200" y="170" text-anchor="middle">multi-repo orchestration</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template">
     <title>ralph-loop template — Autonomous development loop with Claude Code, TDD, and kanban</title>
-    <rect class="box" x="260" y="136" width="180" height="48" rx="5"/>
-    <text class="repo-name" x="350" y="155" text-anchor="middle">ralph-loop template</text>
-    <text class="repo-desc" x="350" y="170" text-anchor="middle">autonomous dev loop</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/claude-code-utils-plugin">
-    <title>claude-code-utils-plugin — CC plugin marketplace with skills, rules, and scripts</title>
-    <rect class="box" x="460" y="136" width="180" height="48" rx="5"/>
-    <text class="repo-name" x="550" y="155" text-anchor="middle">cc-utils-plugin</text>
-    <text class="repo-desc" x="550" y="170" text-anchor="middle">plugins &amp; skills</text>
+    <rect class="box" x="340" y="136" width="220" height="48" rx="5"/>
+    <text class="repo-name" x="450" y="155" text-anchor="middle">ralph-loop template</text>
+    <text class="repo-desc" x="450" y="170" text-anchor="middle">autonomous dev loop</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/coding-agents-research">
     <title>coding-agents-research — Field research and feature analysis for Claude Code</title>
-    <rect class="box" x="660" y="136" width="180" height="48" rx="5"/>
-    <text class="repo-name" x="750" y="155" text-anchor="middle">coding-agents-research</text>
-    <text class="repo-desc" x="750" y="170" text-anchor="middle">CC field research</text>
+    <rect class="box" x="590" y="136" width="220" height="48" rx="5"/>
+    <text class="repo-name" x="700" y="155" text-anchor="middle">coding-agents-research</text>
+    <text class="repo-desc" x="700" y="170" text-anchor="middle">CC field research</text>
   </a>
 
   <!-- ===== Layer 3: AI Agent Evaluation (6 boxes, w=134, gap=12, start=18) ===== -->
@@ -189,54 +182,43 @@
     <text class="repo-desc" x="816" y="330" text-anchor="middle">repo mirroring</text>
   </a>
 
-  <!-- ===== Layer 5: ML / DL Foundations (2 boxes, w=220) ===== -->
-  <rect class="layer-bg" x="10" y="358" width="880" height="74" rx="6"/>
-  <text class="layer-label" x="20" y="372">ML / DL FOUNDATIONS</text>
-
-  <a xlink:href="https://github.com/qte77/App-BERT-Benchmark">
-    <title>App-BERT-Benchmark — BERT configuration benchmarking with HF and W&amp;B</title>
-    <rect class="box" x="220" y="376" width="220" height="48" rx="5"/>
-    <text class="repo-name" x="330" y="395" text-anchor="middle">App-BERT-Benchmark</text>
-    <text class="repo-desc" x="330" y="410" text-anchor="middle">BERT config benchmarks</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/HybridRAG-eval">
-    <title>HybridRAG-eval — Classic vs Hybrid RAG evaluation</title>
-    <rect class="box" x="460" y="376" width="220" height="48" rx="5"/>
-    <text class="repo-name" x="570" y="395" text-anchor="middle">HybridRAG-eval</text>
-    <text class="repo-desc" x="570" y="410" text-anchor="middle">RAG evaluation</text>
-  </a>
-
-  <!-- ===== Layer 6: Infrastructure (1 box) ===== -->
-  <rect class="layer-bg" x="10" y="438" width="880" height="62" rx="6"/>
-  <text class="layer-label" x="20" y="452">INFRASTRUCTURE</text>
+  <!-- ===== Layer 5: Infrastructure (2 boxes, w=220, gap=40, start=210) ===== -->
+  <rect class="layer-bg" x="10" y="358" width="880" height="62" rx="6"/>
+  <text class="layer-label" x="20" y="372">INFRASTRUCTURE</text>
 
   <a xlink:href="https://github.com/qte77/dotfiles">
     <title>dotfiles — Personal dev environment config for Codespaces and devcontainers</title>
-    <rect class="box" x="350" y="454" width="200" height="38" rx="5"/>
-    <text class="repo-name" x="450" y="469" text-anchor="middle">dotfiles</text>
-    <text class="repo-desc" x="450" y="483" text-anchor="middle">dev environment config</text>
+    <rect class="box" x="210" y="374" width="220" height="38" rx="5"/>
+    <text class="repo-name" x="320" y="389" text-anchor="middle">dotfiles</text>
+    <text class="repo-desc" x="320" y="403" text-anchor="middle">dev environment config</text>
   </a>
 
-  <!-- ===== Layer 7: Experimental (2 boxes, w=220, gap=40, start=210) ===== -->
-  <rect class="layer-bg" x="10" y="506" width="880" height="62" rx="6"/>
-  <text class="layer-label" x="20" y="520">EXPERIMENTAL</text>
+  <a xlink:href="https://github.com/qte77/claude-code-utils-plugin">
+    <title>claude-code-utils-plugin — CC plugin marketplace with skills, rules, and scripts</title>
+    <rect class="box" x="470" y="374" width="220" height="38" rx="5"/>
+    <text class="repo-name" x="580" y="389" text-anchor="middle">cc-utils-plugin</text>
+    <text class="repo-desc" x="580" y="403" text-anchor="middle">plugins &amp; skills</text>
+  </a>
+
+  <!-- ===== Layer 6: Experimental (2 boxes, w=220, gap=40, start=210) ===== -->
+  <rect class="layer-bg" x="10" y="426" width="880" height="62" rx="6"/>
+  <text class="layer-label" x="20" y="440">EXPERIMENTAL</text>
 
   <a xlink:href="https://github.com/qte77/cc-recursive-team-mode">
     <title>cc-recursive-team-mode — Claude Code subprocess wrapper, recursive spawning, and artifact parser</title>
-    <rect class="box" x="210" y="522" width="220" height="38" rx="5"/>
-    <text class="repo-name" x="320" y="537" text-anchor="middle">cc-recursive-team</text>
-    <text class="repo-desc" x="320" y="551" text-anchor="middle">recursive agent spawning</text>
+    <rect class="box" x="210" y="442" width="220" height="38" rx="5"/>
+    <text class="repo-name" x="320" y="457" text-anchor="middle">cc-recursive-team</text>
+    <text class="repo-desc" x="320" y="471" text-anchor="middle">recursive agent spawning</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/liminal-flux-gh-acc">
     <title>liminal-flux — Self-evolving agent-operated GitHub account (Lim Sid)</title>
-    <rect class="box" x="470" y="522" width="220" height="38" rx="5"/>
-    <text class="repo-name" x="580" y="537" text-anchor="middle">liminal-flux</text>
-    <text class="repo-desc" x="580" y="551" text-anchor="middle">agent-operated GH account</text>
+    <rect class="box" x="470" y="442" width="220" height="38" rx="5"/>
+    <text class="repo-name" x="580" y="457" text-anchor="middle">liminal-flux</text>
+    <text class="repo-desc" x="580" y="471" text-anchor="middle">agent-operated GH account</text>
   </a>
 
   <!-- Footer -->
-  <text class="note" x="20" y="586">* pat-tax/ org</text>
-  <text class="note" x="880" y="586" text-anchor="end">23 repositories</text>
+  <text class="note" x="20" y="506">* pat-tax/ org</text>
+  <text class="note" x="880" y="506" text-anchor="end">21 repositories</text>
 </svg>

--- a/assets/images/architecture.svg
+++ b/assets/images/architecture.svg
@@ -87,46 +87,46 @@
   <rect class="layer-bg" x="10" y="198" width="880" height="74" rx="6"/>
   <text class="layer-label" x="20" y="212">AI AGENT EVALUATION</text>
 
-  <a xlink:href="https://github.com/qte77/Agents-eval">
-    <title>Agents-eval — Flagship MAS evaluation framework with 3-tier scoring</title>
-    <rect class="box" x="18" y="216" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="85" y="235" text-anchor="middle">Agents-eval</text>
-    <text class="repo-desc" x="85" y="250" text-anchor="middle">3-tier MAS evaluation</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/RDI-AgentBeats-MAS-GraphJudge">
-    <title>MAS-GraphJudge — Graph-based agent collaboration benchmarking</title>
-    <rect class="box" x="164" y="216" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="231" y="235" text-anchor="middle">MAS-GraphJudge</text>
-    <text class="repo-desc" x="231" y="250" text-anchor="middle">graph benchmarking</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/RDI-AgentBeats-TestBehaveAlign">
-    <title>TestBehaveAlign — Test quality evaluation for coding agents</title>
-    <rect class="box" x="310" y="216" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="377" y="235" text-anchor="middle">TestBehaveAlign</text>
-    <text class="repo-desc" x="377" y="250" text-anchor="middle">TDD/BDD test quality</text>
-  </a>
-
-  <a xlink:href="https://github.com/pat-tax/RDI-AgentBeats-TheBulletproofProtocol">
-    <title>TheBulletproofProtocol — Adversarial agent system for R&amp;D tax credit audit (pat-tax org)</title>
-    <rect class="box" x="456" y="216" width="134" height="48" rx="5" stroke-dasharray="4 2"/>
-    <text class="repo-name" x="523" y="235" text-anchor="middle">BulletproofProtocol*</text>
-    <text class="repo-desc" x="523" y="250" text-anchor="middle">adversarial R&amp;D audit</text>
-  </a>
-
   <a xlink:href="https://github.com/qte77/coding-agent-eval">
     <title>coding-agent-eval — Hands-off coding agent comparison harness</title>
-    <rect class="box" x="602" y="216" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="669" y="235" text-anchor="middle">coding-agent-eval</text>
-    <text class="repo-desc" x="669" y="250" text-anchor="middle">CC evaluation harness</text>
+    <rect class="box" x="18" y="216" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="85" y="235" text-anchor="middle">coding-agent-eval</text>
+    <text class="repo-desc" x="85" y="250" text-anchor="middle">CC evaluation harness</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/multi-tasking-quality-benchmark">
     <title>multi-tasking-quality-benchmark — WakaTime activity vs code quality correlation</title>
+    <rect class="box" x="164" y="216" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="231" y="235" text-anchor="middle">multi-tasking-quality</text>
+    <text class="repo-desc" x="231" y="250" text-anchor="middle">WakaTime correlation</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/RDI-AgentBeats-MAS-GraphJudge">
+    <title>MAS-GraphJudge — Graph-based agent collaboration benchmarking</title>
+    <rect class="box" x="310" y="216" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="377" y="235" text-anchor="middle">MAS-GraphJudge</text>
+    <text class="repo-desc" x="377" y="250" text-anchor="middle">graph benchmarking</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/RDI-AgentBeats-TestBehaveAlign">
+    <title>TestBehaveAlign — Test quality evaluation for coding agents</title>
+    <rect class="box" x="456" y="216" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="523" y="235" text-anchor="middle">TestBehaveAlign</text>
+    <text class="repo-desc" x="523" y="250" text-anchor="middle">TDD/BDD test quality</text>
+  </a>
+
+  <a xlink:href="https://github.com/pat-tax/RDI-AgentBeats-TheBulletproofProtocol">
+    <title>TheBulletproofProtocol — Adversarial agent system for R&amp;D tax credit audit (pat-tax org)</title>
+    <rect class="box" x="602" y="216" width="134" height="48" rx="5" stroke-dasharray="4 2"/>
+    <text class="repo-name" x="669" y="235" text-anchor="middle">BulletproofProtocol*</text>
+    <text class="repo-desc" x="669" y="250" text-anchor="middle">adversarial R&amp;D audit</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/Agents-eval">
+    <title>Agents-eval — Flagship MAS evaluation framework with 3-tier scoring</title>
     <rect class="box" x="748" y="216" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="815" y="235" text-anchor="middle">multi-tasking-quality</text>
-    <text class="repo-desc" x="815" y="250" text-anchor="middle">WakaTime correlation</text>
+    <text class="repo-name" x="815" y="235" text-anchor="middle">Agents-eval</text>
+    <text class="repo-desc" x="815" y="250" text-anchor="middle">3-tier MAS evaluation</text>
   </a>
 
   <!-- ===== Layer 4: GitHub Actions (7 boxes, w=112, gap=10, start=28) ===== -->

--- a/assets/images/architecture.svg
+++ b/assets/images/architecture.svg
@@ -33,121 +33,121 @@
   <!-- Title -->
   <text class="title" x="450" y="24" text-anchor="middle">qte77 — Project Ecosystem</text>
 
-  <!-- ===== Layer 1: AI Agent Evaluation (6 boxes, w=134, gap=12, start=18) ===== -->
+  <!-- ===== Layer 1: Product & Business Steering (3 boxes, w=220, gap=30, start=90) ===== -->
   <rect class="layer-bg" x="10" y="38" width="880" height="74" rx="6"/>
-  <text class="layer-label" x="20" y="52">AI AGENT EVALUATION</text>
-
-  <a xlink:href="https://github.com/qte77/Agents-eval">
-    <title>Agents-eval — Flagship MAS evaluation framework with 3-tier scoring</title>
-    <rect class="box" x="18" y="56" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="85" y="75" text-anchor="middle">Agents-eval</text>
-    <text class="repo-desc" x="85" y="90" text-anchor="middle">3-tier MAS evaluation</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/RDI-AgentBeats-MAS-GraphJudge">
-    <title>MAS-GraphJudge — Graph-based agent collaboration benchmarking</title>
-    <rect class="box" x="164" y="56" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="231" y="75" text-anchor="middle">MAS-GraphJudge</text>
-    <text class="repo-desc" x="231" y="90" text-anchor="middle">graph benchmarking</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/RDI-AgentBeats-TestBehaveAlign">
-    <title>TestBehaveAlign — Test quality evaluation for coding agents</title>
-    <rect class="box" x="310" y="56" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="377" y="75" text-anchor="middle">TestBehaveAlign</text>
-    <text class="repo-desc" x="377" y="90" text-anchor="middle">TDD/BDD test quality</text>
-  </a>
-
-  <a xlink:href="https://github.com/pat-tax/RDI-AgentBeats-TheBulletproofProtocol">
-    <title>TheBulletproofProtocol — Adversarial agent system for R&amp;D tax credit audit (pat-tax org)</title>
-    <rect class="box" x="456" y="56" width="134" height="48" rx="5" stroke-dasharray="4 2"/>
-    <text class="repo-name" x="523" y="75" text-anchor="middle">BulletproofProtocol*</text>
-    <text class="repo-desc" x="523" y="90" text-anchor="middle">adversarial R&amp;D audit</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/coding-agent-eval">
-    <title>coding-agent-eval — Hands-off coding agent comparison harness</title>
-    <rect class="box" x="602" y="56" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="669" y="75" text-anchor="middle">coding-agent-eval</text>
-    <text class="repo-desc" x="669" y="90" text-anchor="middle">CC evaluation harness</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/multi-tasking-quality-benchmark">
-    <title>multi-tasking-quality-benchmark — WakaTime activity vs code quality correlation</title>
-    <rect class="box" x="748" y="56" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="815" y="75" text-anchor="middle">multi-tasking-quality</text>
-    <text class="repo-desc" x="815" y="90" text-anchor="middle">WakaTime correlation</text>
-  </a>
-
-  <!-- ===== Layer 2: Agent Development Tooling (6 boxes, w=134, gap=12, start=18) ===== -->
-  <rect class="layer-bg" x="10" y="118" width="880" height="74" rx="6"/>
-  <text class="layer-label" x="20" y="132">AGENT DEVELOPMENT TOOLING</text>
-
-  <a xlink:href="https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template">
-    <title>ralph-loop template — Autonomous development loop with Claude Code</title>
-    <rect class="box" x="18" y="136" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="85" y="155" text-anchor="middle">ralph-loop template</text>
-    <text class="repo-desc" x="85" y="170" text-anchor="middle">autonomous dev loop</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/claude-code-utils-plugin">
-    <title>claude-code-utils-plugin — CC plugin marketplace with skills and rules</title>
-    <rect class="box" x="164" y="136" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="231" y="155" text-anchor="middle">cc-utils-plugin</text>
-    <text class="repo-desc" x="231" y="170" text-anchor="middle">plugins &amp; skills</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/cc-recursive-team-mode">
-    <title>cc-recursive-team-mode — Claude Code subprocess wrapper and artifact parser</title>
-    <rect class="box" x="310" y="136" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="377" y="155" text-anchor="middle">cc-recursive-team</text>
-    <text class="repo-desc" x="377" y="170" text-anchor="middle">CC subprocess wrapper</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/polyforge">
-    <title>polyforge — Multi-repo AI agent orchestration</title>
-    <rect class="box" x="456" y="136" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="523" y="155" text-anchor="middle">polyforge</text>
-    <text class="repo-desc" x="523" y="170" text-anchor="middle">multi-repo orchestration</text>
-  </a>
+  <text class="layer-label" x="20" y="52">PRODUCT &amp; BUSINESS STEERING</text>
 
   <a xlink:href="https://github.com/qte77/CABIO-test">
-    <title>CABIO-test — Context-Aware Business Intelligence Orchestration</title>
-    <rect class="box" x="602" y="136" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="669" y="155" text-anchor="middle">CABIO-test</text>
-    <text class="repo-desc" x="669" y="170" text-anchor="middle">business orchestration</text>
+    <title>CABIO-test — Context-Aware Business Intelligence Orchestration and lifecycle management</title>
+    <rect class="box" x="90" y="56" width="220" height="48" rx="5"/>
+    <text class="repo-name" x="200" y="75" text-anchor="middle">CABIO-test</text>
+    <text class="repo-desc" x="200" y="90" text-anchor="middle">business &amp; lifecycle mgmt</text>
   </a>
-
-  <a xlink:href="https://github.com/qte77/coding-agents-research">
-    <title>coding-agents-research — Claude Code field research and feature analysis</title>
-    <rect class="box" x="748" y="136" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="815" y="155" text-anchor="middle">coding-agents-research</text>
-    <text class="repo-desc" x="815" y="170" text-anchor="middle">Claude Code research</text>
-  </a>
-
-  <!-- ===== Layer 3: Agent Applications (3 boxes, w=220, gap=30, start=90) ===== -->
-  <rect class="layer-bg" x="10" y="198" width="880" height="74" rx="6"/>
-  <text class="layer-label" x="20" y="212">AGENT APPLICATIONS</text>
 
   <a xlink:href="https://github.com/qte77/agentic-market-research-to-gtm">
     <title>agentic-market-research-to-gtm — Automated market research and GTM pipeline</title>
-    <rect class="box" x="90" y="216" width="220" height="48" rx="5"/>
-    <text class="repo-name" x="200" y="235" text-anchor="middle">market-research-to-gtm</text>
-    <text class="repo-desc" x="200" y="250" text-anchor="middle">AI market research</text>
+    <rect class="box" x="340" y="56" width="220" height="48" rx="5"/>
+    <text class="repo-name" x="450" y="75" text-anchor="middle">market-research-to-gtm</text>
+    <text class="repo-desc" x="450" y="90" text-anchor="middle">AI market research</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/agentic-codebase-to-scientific-report">
     <title>agentic-codebase-to-scientific-report — Automated scientific report generation from codebases</title>
-    <rect class="box" x="340" y="216" width="220" height="48" rx="5"/>
-    <text class="repo-name" x="450" y="235" text-anchor="middle">codebase-to-report</text>
-    <text class="repo-desc" x="450" y="250" text-anchor="middle">scientific report gen</text>
+    <rect class="box" x="590" y="56" width="220" height="48" rx="5"/>
+    <text class="repo-name" x="700" y="75" text-anchor="middle">codebase-to-report</text>
+    <text class="repo-desc" x="700" y="90" text-anchor="middle">scientific report gen</text>
+  </a>
+
+  <!-- ===== Layer 2: Agentic Development Engine (5 boxes, w=150, gap=15, start=45) ===== -->
+  <rect class="layer-bg" x="10" y="118" width="880" height="74" rx="6"/>
+  <text class="layer-label" x="20" y="132">AGENTIC DEVELOPMENT ENGINE</text>
+
+  <a xlink:href="https://github.com/qte77/polyforge">
+    <title>polyforge — Polyrepo dev forge for parallel AI agent workflows across multiple repositories</title>
+    <rect class="box" x="45" y="136" width="150" height="48" rx="5"/>
+    <text class="repo-name" x="120" y="155" text-anchor="middle">polyforge</text>
+    <text class="repo-desc" x="120" y="170" text-anchor="middle">multi-repo orchestration</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template">
+    <title>ralph-loop template — Autonomous development loop with Claude Code, TDD, and kanban</title>
+    <rect class="box" x="210" y="136" width="150" height="48" rx="5"/>
+    <text class="repo-name" x="285" y="155" text-anchor="middle">ralph-loop template</text>
+    <text class="repo-desc" x="285" y="170" text-anchor="middle">autonomous dev loop</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/cc-recursive-team-mode">
+    <title>cc-recursive-team-mode — Claude Code subprocess wrapper, recursive spawning, and artifact parser</title>
+    <rect class="box" x="375" y="136" width="150" height="48" rx="5"/>
+    <text class="repo-name" x="450" y="155" text-anchor="middle">cc-recursive-team</text>
+    <text class="repo-desc" x="450" y="170" text-anchor="middle">recursive agent spawning</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/claude-code-utils-plugin">
+    <title>claude-code-utils-plugin — CC plugin marketplace with skills, rules, and scripts</title>
+    <rect class="box" x="540" y="136" width="150" height="48" rx="5"/>
+    <text class="repo-name" x="615" y="155" text-anchor="middle">cc-utils-plugin</text>
+    <text class="repo-desc" x="615" y="170" text-anchor="middle">plugins &amp; skills</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/coding-agents-research">
+    <title>coding-agents-research — Field research and feature analysis for Claude Code</title>
+    <rect class="box" x="705" y="136" width="150" height="48" rx="5"/>
+    <text class="repo-name" x="780" y="155" text-anchor="middle">coding-agents-research</text>
+    <text class="repo-desc" x="780" y="170" text-anchor="middle">CC field research</text>
+  </a>
+
+  <!-- ===== Layer 3: AI Agent Evaluation (7 boxes, w=112, gap=10, start=28) ===== -->
+  <rect class="layer-bg" x="10" y="198" width="880" height="74" rx="6"/>
+  <text class="layer-label" x="20" y="212">AI AGENT EVALUATION</text>
+
+  <a xlink:href="https://github.com/qte77/Agents-eval">
+    <title>Agents-eval — Flagship MAS evaluation framework with 3-tier scoring</title>
+    <rect class="box" x="28" y="216" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="84" y="235" text-anchor="middle">Agents-eval</text>
+    <text class="repo-desc" x="84" y="250" text-anchor="middle">3-tier MAS evaluation</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/RDI-AgentBeats-MAS-GraphJudge">
+    <title>MAS-GraphJudge — Graph-based agent collaboration benchmarking</title>
+    <rect class="box" x="150" y="216" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="206" y="235" text-anchor="middle">MAS-GraphJudge</text>
+    <text class="repo-desc" x="206" y="250" text-anchor="middle">graph benchmarking</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/RDI-AgentBeats-TestBehaveAlign">
+    <title>TestBehaveAlign — Test quality evaluation for coding agents</title>
+    <rect class="box" x="272" y="216" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="328" y="235" text-anchor="middle">TestBehaveAlign</text>
+    <text class="repo-desc" x="328" y="250" text-anchor="middle">TDD/BDD test quality</text>
+  </a>
+
+  <a xlink:href="https://github.com/pat-tax/RDI-AgentBeats-TheBulletproofProtocol">
+    <title>TheBulletproofProtocol — Adversarial agent system for R&amp;D tax credit audit (pat-tax org)</title>
+    <rect class="box" x="394" y="216" width="112" height="48" rx="5" stroke-dasharray="4 2"/>
+    <text class="repo-name" x="450" y="235" text-anchor="middle">BulletproofProtocol*</text>
+    <text class="repo-desc" x="450" y="250" text-anchor="middle">adversarial R&amp;D audit</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/coding-agent-eval">
+    <title>coding-agent-eval — Hands-off coding agent comparison harness</title>
+    <rect class="box" x="516" y="216" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="572" y="235" text-anchor="middle">coding-agent-eval</text>
+    <text class="repo-desc" x="572" y="250" text-anchor="middle">CC evaluation harness</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/multi-tasking-quality-benchmark">
+    <title>multi-tasking-quality-benchmark — WakaTime activity vs code quality correlation</title>
+    <rect class="box" x="638" y="216" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="694" y="235" text-anchor="middle">multi-tasking-quality</text>
+    <text class="repo-desc" x="694" y="250" text-anchor="middle">WakaTime correlation</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/liminal-flux-gh-acc">
-    <title>liminal-flux — Self-evolving agent-operated GitHub account (Lim Sid)</title>
-    <rect class="box" x="590" y="216" width="220" height="48" rx="5"/>
-    <text class="repo-name" x="700" y="235" text-anchor="middle">liminal-flux</text>
-    <text class="repo-desc" x="700" y="250" text-anchor="middle">agent-operated GH account</text>
+    <title>liminal-flux — Self-evolving agent-operated GitHub account (experimental)</title>
+    <rect class="box" x="760" y="216" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="816" y="235" text-anchor="middle">liminal-flux</text>
+    <text class="repo-desc" x="816" y="250" text-anchor="middle">experimental GH account</text>
   </a>
 
   <!-- ===== Layer 4: GitHub Actions (7 boxes, w=112, gap=10, start=28) ===== -->
@@ -203,7 +203,7 @@
     <text class="repo-desc" x="816" y="330" text-anchor="middle">repo mirroring</text>
   </a>
 
-  <!-- ===== Layer 5: ML / DL Foundations (2 boxes, w=220, unchanged) ===== -->
+  <!-- ===== Layer 5: ML / DL Foundations (2 boxes, w=220) ===== -->
   <rect class="layer-bg" x="10" y="358" width="880" height="74" rx="6"/>
   <text class="layer-label" x="20" y="372">ML / DL FOUNDATIONS</text>
 
@@ -221,7 +221,7 @@
     <text class="repo-desc" x="570" y="410" text-anchor="middle">RAG evaluation</text>
   </a>
 
-  <!-- ===== Layer 6: Infrastructure (1 box, unchanged) ===== -->
+  <!-- ===== Layer 6: Infrastructure (1 box) ===== -->
   <rect class="layer-bg" x="10" y="438" width="880" height="62" rx="6"/>
   <text class="layer-label" x="20" y="452">INFRASTRUCTURE</text>
 

--- a/assets/images/architecture.svg
+++ b/assets/images/architecture.svg
@@ -33,7 +33,7 @@
   <!-- Title -->
   <text class="title" x="450" y="24" text-anchor="middle">qte77 — Project Ecosystem</text>
 
-  <!-- ===== Layer 1: AI Agent Evaluation ===== -->
+  <!-- ===== Layer 1: AI Agent Evaluation (6 boxes, w=134, gap=12, start=18) ===== -->
   <rect class="layer-bg" x="10" y="38" width="880" height="74" rx="6"/>
   <text class="layer-label" x="20" y="52">AI AGENT EVALUATION</text>
 
@@ -79,110 +79,138 @@
     <text class="repo-desc" x="815" y="90" text-anchor="middle">WakaTime correlation</text>
   </a>
 
-  <!-- ===== Layer 2: Agent Development Tooling ===== -->
+  <!-- ===== Layer 2: Agent Development Tooling (7 boxes, w=112, gap=10, start=28) ===== -->
   <rect class="layer-bg" x="10" y="118" width="880" height="74" rx="6"/>
   <text class="layer-label" x="20" y="132">AGENT DEVELOPMENT TOOLING</text>
 
   <a xlink:href="https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template">
     <title>ralph-loop template — Autonomous development loop with Claude Code</title>
-    <rect class="box" x="18" y="136" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="85" y="155" text-anchor="middle">ralph-loop template</text>
-    <text class="repo-desc" x="85" y="170" text-anchor="middle">autonomous dev loop</text>
+    <rect class="box" x="28" y="136" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="84" y="155" text-anchor="middle">ralph-loop</text>
+    <text class="repo-desc" x="84" y="170" text-anchor="middle">autonomous dev loop</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/claude-code-utils-plugin">
     <title>claude-code-utils-plugin — CC plugin marketplace with skills and rules</title>
-    <rect class="box" x="164" y="136" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="231" y="155" text-anchor="middle">cc-utils-plugin</text>
-    <text class="repo-desc" x="231" y="170" text-anchor="middle">plugins &amp; skills</text>
+    <rect class="box" x="150" y="136" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="206" y="155" text-anchor="middle">cc-utils-plugin</text>
+    <text class="repo-desc" x="206" y="170" text-anchor="middle">plugins &amp; skills</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/cc-recursive-team-mode">
     <title>cc-recursive-team-mode — Claude Code subprocess wrapper and artifact parser</title>
-    <rect class="box" x="310" y="136" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="377" y="155" text-anchor="middle">cc-recursive-team</text>
-    <text class="repo-desc" x="377" y="170" text-anchor="middle">CC subprocess wrapper</text>
+    <rect class="box" x="272" y="136" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="328" y="155" text-anchor="middle">cc-recursive-team</text>
+    <text class="repo-desc" x="328" y="170" text-anchor="middle">CC subprocess wrapper</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/polyforge">
     <title>polyforge — Multi-repo AI agent orchestration</title>
-    <rect class="box" x="456" y="136" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="523" y="155" text-anchor="middle">polyforge</text>
-    <text class="repo-desc" x="523" y="170" text-anchor="middle">multi-repo orchestration</text>
+    <rect class="box" x="394" y="136" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="450" y="155" text-anchor="middle">polyforge</text>
+    <text class="repo-desc" x="450" y="170" text-anchor="middle">multi-repo orchestration</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/CABIO-test">
     <title>CABIO-test — Context-Aware Business Intelligence Orchestration</title>
-    <rect class="box" x="602" y="136" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="669" y="155" text-anchor="middle">CABIO-test</text>
-    <text class="repo-desc" x="669" y="170" text-anchor="middle">business workflows</text>
+    <rect class="box" x="516" y="136" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="572" y="155" text-anchor="middle">CABIO-test</text>
+    <text class="repo-desc" x="572" y="170" text-anchor="middle">business workflows</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/coding-agents-research">
     <title>coding-agents-research — Claude Code field research and feature analysis</title>
-    <rect class="box" x="748" y="136" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="815" y="155" text-anchor="middle">coding-agents-research</text>
-    <text class="repo-desc" x="815" y="170" text-anchor="middle">Claude Code research</text>
+    <rect class="box" x="638" y="136" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="694" y="155" text-anchor="middle">agents-research</text>
+    <text class="repo-desc" x="694" y="170" text-anchor="middle">Claude Code research</text>
   </a>
 
-  <!-- ===== Layer 3: Agent Applications ===== -->
+  <a xlink:href="https://github.com/qte77/sdlc-lcm-manager">
+    <title>sdlc-lcm-manager — SDLC lifecycle management and tracking</title>
+    <rect class="box" x="760" y="136" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="816" y="155" text-anchor="middle">sdlc-lcm-manager</text>
+    <text class="repo-desc" x="816" y="170" text-anchor="middle">lifecycle management</text>
+  </a>
+
+  <!-- ===== Layer 3: Agent Applications (3 boxes, w=220, gap=30, start=90) ===== -->
   <rect class="layer-bg" x="10" y="198" width="880" height="74" rx="6"/>
   <text class="layer-label" x="20" y="212">AGENT APPLICATIONS</text>
 
   <a xlink:href="https://github.com/qte77/agentic-market-research-to-gtm">
     <title>agentic-market-research-to-gtm — Automated market research and GTM pipeline</title>
-    <rect class="box" x="220" y="216" width="220" height="48" rx="5"/>
-    <text class="repo-name" x="330" y="235" text-anchor="middle">market-research-to-gtm</text>
-    <text class="repo-desc" x="330" y="250" text-anchor="middle">AI market research</text>
+    <rect class="box" x="90" y="216" width="220" height="48" rx="5"/>
+    <text class="repo-name" x="200" y="235" text-anchor="middle">market-research-to-gtm</text>
+    <text class="repo-desc" x="200" y="250" text-anchor="middle">AI market research</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/agentic-codebase-to-scientific-report">
     <title>agentic-codebase-to-scientific-report — Automated scientific report generation from codebases</title>
-    <rect class="box" x="460" y="216" width="220" height="48" rx="5"/>
-    <text class="repo-name" x="570" y="235" text-anchor="middle">codebase-to-report</text>
-    <text class="repo-desc" x="570" y="250" text-anchor="middle">scientific report gen</text>
+    <rect class="box" x="340" y="216" width="220" height="48" rx="5"/>
+    <text class="repo-name" x="450" y="235" text-anchor="middle">codebase-to-report</text>
+    <text class="repo-desc" x="450" y="250" text-anchor="middle">scientific report gen</text>
   </a>
 
-  <!-- ===== Layer 4: GitHub Actions ===== -->
+  <a xlink:href="https://github.com/qte77/liminal-flux-gh-acc">
+    <title>liminal-flux — Self-evolving agent-operated GitHub account (Lim Sid)</title>
+    <rect class="box" x="590" y="216" width="220" height="48" rx="5"/>
+    <text class="repo-name" x="700" y="235" text-anchor="middle">liminal-flux</text>
+    <text class="repo-desc" x="700" y="250" text-anchor="middle">agent-operated GH account</text>
+  </a>
+
+  <!-- ===== Layer 4: GitHub Actions (7 boxes, w=112, gap=10, start=28) ===== -->
   <rect class="layer-bg" x="10" y="278" width="880" height="74" rx="6"/>
   <text class="layer-label" x="20" y="292">GITHUB ACTIONS</text>
 
   <a xlink:href="https://github.com/qte77/gha-ai-changelog">
     <title>gha-ai-changelog — AI-powered changelog generation from PRs</title>
-    <rect class="box" x="91" y="296" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="158" y="315" text-anchor="middle">ai-changelog</text>
-    <text class="repo-desc" x="158" y="330" text-anchor="middle">AI-powered changelogs</text>
+    <rect class="box" x="28" y="296" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="84" y="315" text-anchor="middle">ai-changelog</text>
+    <text class="repo-desc" x="84" y="330" text-anchor="middle">AI-powered changelogs</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-contribution-ascii">
     <title>gha-contribution-ascii — Write ASCII art onto GitHub contribution graph</title>
-    <rect class="box" x="237" y="296" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="304" y="315" text-anchor="middle">contribution-ascii</text>
-    <text class="repo-desc" x="304" y="330" text-anchor="middle">contribution graph art</text>
+    <rect class="box" x="150" y="296" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="206" y="315" text-anchor="middle">contribution-ascii</text>
+    <text class="repo-desc" x="206" y="330" text-anchor="middle">contribution graph art</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-dirtree-to-readme">
     <title>gha-dirtree-to-readme — Auto-insert directory tree into README</title>
-    <rect class="box" x="383" y="296" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="450" y="315" text-anchor="middle">dirtree-to-readme</text>
-    <text class="repo-desc" x="450" y="330" text-anchor="middle">dir tree to README</text>
+    <rect class="box" x="272" y="296" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="328" y="315" text-anchor="middle">dirtree-to-readme</text>
+    <text class="repo-desc" x="328" y="330" text-anchor="middle">dir tree to README</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-arxiv-stats-action">
     <title>gha-arxiv-stats-action — Logs daily stats of papers submitted to arxiv.org</title>
-    <rect class="box" x="529" y="296" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="596" y="315" text-anchor="middle">arxiv-stats-action</text>
-    <text class="repo-desc" x="596" y="330" text-anchor="middle">arXiv daily paper stats</text>
+    <rect class="box" x="394" y="296" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="450" y="315" text-anchor="middle">arxiv-stats-action</text>
+    <text class="repo-desc" x="450" y="330" text-anchor="middle">arXiv daily paper stats</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-cross-repo-issue-sync">
     <title>gha-cross-repo-issue-sync — Synchronize issues across repositories</title>
-    <rect class="box" x="675" y="296" width="134" height="48" rx="5"/>
-    <text class="repo-name" x="742" y="315" text-anchor="middle">cross-repo-issue-sync</text>
-    <text class="repo-desc" x="742" y="330" text-anchor="middle">issue synchronization</text>
+    <rect class="box" x="516" y="296" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="572" y="315" text-anchor="middle">issue-sync</text>
+    <text class="repo-desc" x="572" y="330" text-anchor="middle">cross-repo issues</text>
   </a>
 
-  <!-- ===== Layer 5: ML / DL Foundations ===== -->
+  <a xlink:href="https://github.com/qte77/gha-arbitrary-repo-timeline">
+    <title>gha-arbitrary-repo-timeline — Generate timeline visualizations for any repo</title>
+    <rect class="box" x="638" y="296" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="694" y="315" text-anchor="middle">repo-timeline</text>
+    <text class="repo-desc" x="694" y="330" text-anchor="middle">repo timeline viz</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/gha-github-mirror-action">
+    <title>gha-github-mirror-action — Mirror repositories across GitHub accounts</title>
+    <rect class="box" x="760" y="296" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="816" y="315" text-anchor="middle">github-mirror</text>
+    <text class="repo-desc" x="816" y="330" text-anchor="middle">repo mirroring</text>
+  </a>
+
+  <!-- ===== Layer 5: ML / DL Foundations (2 boxes, w=220, unchanged) ===== -->
   <rect class="layer-bg" x="10" y="358" width="880" height="74" rx="6"/>
   <text class="layer-label" x="20" y="372">ML / DL FOUNDATIONS</text>
 
@@ -200,7 +228,7 @@
     <text class="repo-desc" x="570" y="410" text-anchor="middle">RAG evaluation</text>
   </a>
 
-  <!-- ===== Layer 6: Infrastructure ===== -->
+  <!-- ===== Layer 6: Infrastructure (1 box, unchanged) ===== -->
   <rect class="layer-bg" x="10" y="438" width="880" height="62" rx="6"/>
   <text class="layer-label" x="20" y="452">INFRASTRUCTURE</text>
 
@@ -213,5 +241,5 @@
 
   <!-- Footer -->
   <text class="note" x="20" y="518">* pat-tax/ org</text>
-  <text class="note" x="880" y="518" text-anchor="end">21 original repositories</text>
+  <text class="note" x="880" y="518" text-anchor="end">24 repositories</text>
 </svg>

--- a/assets/images/architecture.svg
+++ b/assets/images/architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 900 528" width="900" height="528">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 900 596" width="900" height="596">
   <defs>
     <style>
       /* Light mode (default) */
@@ -28,7 +28,7 @@
   </defs>
 
   <!-- Page background -->
-  <rect class="page-bg" width="900" height="528" rx="8"/>
+  <rect class="page-bg" width="900" height="596" rx="8"/>
 
   <!-- Title -->
   <text class="title" x="450" y="24" text-anchor="middle">qte77 — Project Ecosystem</text>
@@ -58,96 +58,82 @@
     <text class="repo-desc" x="700" y="90" text-anchor="middle">scientific report gen</text>
   </a>
 
-  <!-- ===== Layer 2: Agentic Development Engine (5 boxes, w=150, gap=15, start=45) ===== -->
+  <!-- ===== Layer 2: Agentic Development Engine (4 boxes, w=180, gap=20, start=60) ===== -->
   <rect class="layer-bg" x="10" y="118" width="880" height="74" rx="6"/>
   <text class="layer-label" x="20" y="132">AGENTIC DEVELOPMENT ENGINE</text>
 
   <a xlink:href="https://github.com/qte77/polyforge">
     <title>polyforge — Polyrepo dev forge for parallel AI agent workflows across multiple repositories</title>
-    <rect class="box" x="45" y="136" width="150" height="48" rx="5"/>
-    <text class="repo-name" x="120" y="155" text-anchor="middle">polyforge</text>
-    <text class="repo-desc" x="120" y="170" text-anchor="middle">multi-repo orchestration</text>
+    <rect class="box" x="60" y="136" width="180" height="48" rx="5"/>
+    <text class="repo-name" x="150" y="155" text-anchor="middle">polyforge</text>
+    <text class="repo-desc" x="150" y="170" text-anchor="middle">multi-repo orchestration</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template">
     <title>ralph-loop template — Autonomous development loop with Claude Code, TDD, and kanban</title>
-    <rect class="box" x="210" y="136" width="150" height="48" rx="5"/>
-    <text class="repo-name" x="285" y="155" text-anchor="middle">ralph-loop template</text>
-    <text class="repo-desc" x="285" y="170" text-anchor="middle">autonomous dev loop</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/cc-recursive-team-mode">
-    <title>cc-recursive-team-mode — Claude Code subprocess wrapper, recursive spawning, and artifact parser</title>
-    <rect class="box" x="375" y="136" width="150" height="48" rx="5"/>
-    <text class="repo-name" x="450" y="155" text-anchor="middle">cc-recursive-team</text>
-    <text class="repo-desc" x="450" y="170" text-anchor="middle">recursive agent spawning</text>
+    <rect class="box" x="260" y="136" width="180" height="48" rx="5"/>
+    <text class="repo-name" x="350" y="155" text-anchor="middle">ralph-loop template</text>
+    <text class="repo-desc" x="350" y="170" text-anchor="middle">autonomous dev loop</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/claude-code-utils-plugin">
     <title>claude-code-utils-plugin — CC plugin marketplace with skills, rules, and scripts</title>
-    <rect class="box" x="540" y="136" width="150" height="48" rx="5"/>
-    <text class="repo-name" x="615" y="155" text-anchor="middle">cc-utils-plugin</text>
-    <text class="repo-desc" x="615" y="170" text-anchor="middle">plugins &amp; skills</text>
+    <rect class="box" x="460" y="136" width="180" height="48" rx="5"/>
+    <text class="repo-name" x="550" y="155" text-anchor="middle">cc-utils-plugin</text>
+    <text class="repo-desc" x="550" y="170" text-anchor="middle">plugins &amp; skills</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/coding-agents-research">
     <title>coding-agents-research — Field research and feature analysis for Claude Code</title>
-    <rect class="box" x="705" y="136" width="150" height="48" rx="5"/>
-    <text class="repo-name" x="780" y="155" text-anchor="middle">coding-agents-research</text>
-    <text class="repo-desc" x="780" y="170" text-anchor="middle">CC field research</text>
+    <rect class="box" x="660" y="136" width="180" height="48" rx="5"/>
+    <text class="repo-name" x="750" y="155" text-anchor="middle">coding-agents-research</text>
+    <text class="repo-desc" x="750" y="170" text-anchor="middle">CC field research</text>
   </a>
 
-  <!-- ===== Layer 3: AI Agent Evaluation (7 boxes, w=112, gap=10, start=28) ===== -->
+  <!-- ===== Layer 3: AI Agent Evaluation (6 boxes, w=134, gap=12, start=18) ===== -->
   <rect class="layer-bg" x="10" y="198" width="880" height="74" rx="6"/>
   <text class="layer-label" x="20" y="212">AI AGENT EVALUATION</text>
 
   <a xlink:href="https://github.com/qte77/Agents-eval">
     <title>Agents-eval — Flagship MAS evaluation framework with 3-tier scoring</title>
-    <rect class="box" x="28" y="216" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="84" y="235" text-anchor="middle">Agents-eval</text>
-    <text class="repo-desc" x="84" y="250" text-anchor="middle">3-tier MAS evaluation</text>
+    <rect class="box" x="18" y="216" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="85" y="235" text-anchor="middle">Agents-eval</text>
+    <text class="repo-desc" x="85" y="250" text-anchor="middle">3-tier MAS evaluation</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/RDI-AgentBeats-MAS-GraphJudge">
     <title>MAS-GraphJudge — Graph-based agent collaboration benchmarking</title>
-    <rect class="box" x="150" y="216" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="206" y="235" text-anchor="middle">MAS-GraphJudge</text>
-    <text class="repo-desc" x="206" y="250" text-anchor="middle">graph benchmarking</text>
+    <rect class="box" x="164" y="216" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="231" y="235" text-anchor="middle">MAS-GraphJudge</text>
+    <text class="repo-desc" x="231" y="250" text-anchor="middle">graph benchmarking</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/RDI-AgentBeats-TestBehaveAlign">
     <title>TestBehaveAlign — Test quality evaluation for coding agents</title>
-    <rect class="box" x="272" y="216" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="328" y="235" text-anchor="middle">TestBehaveAlign</text>
-    <text class="repo-desc" x="328" y="250" text-anchor="middle">TDD/BDD test quality</text>
+    <rect class="box" x="310" y="216" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="377" y="235" text-anchor="middle">TestBehaveAlign</text>
+    <text class="repo-desc" x="377" y="250" text-anchor="middle">TDD/BDD test quality</text>
   </a>
 
   <a xlink:href="https://github.com/pat-tax/RDI-AgentBeats-TheBulletproofProtocol">
     <title>TheBulletproofProtocol — Adversarial agent system for R&amp;D tax credit audit (pat-tax org)</title>
-    <rect class="box" x="394" y="216" width="112" height="48" rx="5" stroke-dasharray="4 2"/>
-    <text class="repo-name" x="450" y="235" text-anchor="middle">BulletproofProtocol*</text>
-    <text class="repo-desc" x="450" y="250" text-anchor="middle">adversarial R&amp;D audit</text>
+    <rect class="box" x="456" y="216" width="134" height="48" rx="5" stroke-dasharray="4 2"/>
+    <text class="repo-name" x="523" y="235" text-anchor="middle">BulletproofProtocol*</text>
+    <text class="repo-desc" x="523" y="250" text-anchor="middle">adversarial R&amp;D audit</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/coding-agent-eval">
     <title>coding-agent-eval — Hands-off coding agent comparison harness</title>
-    <rect class="box" x="516" y="216" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="572" y="235" text-anchor="middle">coding-agent-eval</text>
-    <text class="repo-desc" x="572" y="250" text-anchor="middle">CC evaluation harness</text>
+    <rect class="box" x="602" y="216" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="669" y="235" text-anchor="middle">coding-agent-eval</text>
+    <text class="repo-desc" x="669" y="250" text-anchor="middle">CC evaluation harness</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/multi-tasking-quality-benchmark">
     <title>multi-tasking-quality-benchmark — WakaTime activity vs code quality correlation</title>
-    <rect class="box" x="638" y="216" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="694" y="235" text-anchor="middle">multi-tasking-quality</text>
-    <text class="repo-desc" x="694" y="250" text-anchor="middle">WakaTime correlation</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/liminal-flux-gh-acc">
-    <title>liminal-flux — Self-evolving agent-operated GitHub account (experimental)</title>
-    <rect class="box" x="760" y="216" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="816" y="235" text-anchor="middle">liminal-flux</text>
-    <text class="repo-desc" x="816" y="250" text-anchor="middle">experimental GH account</text>
+    <rect class="box" x="748" y="216" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="815" y="235" text-anchor="middle">multi-tasking-quality</text>
+    <text class="repo-desc" x="815" y="250" text-anchor="middle">WakaTime correlation</text>
   </a>
 
   <!-- ===== Layer 4: GitHub Actions (7 boxes, w=112, gap=10, start=28) ===== -->
@@ -232,7 +218,25 @@
     <text class="repo-desc" x="450" y="483" text-anchor="middle">dev environment config</text>
   </a>
 
+  <!-- ===== Layer 7: Experimental (2 boxes, w=220, gap=40, start=210) ===== -->
+  <rect class="layer-bg" x="10" y="506" width="880" height="62" rx="6"/>
+  <text class="layer-label" x="20" y="520">EXPERIMENTAL</text>
+
+  <a xlink:href="https://github.com/qte77/cc-recursive-team-mode">
+    <title>cc-recursive-team-mode — Claude Code subprocess wrapper, recursive spawning, and artifact parser</title>
+    <rect class="box" x="210" y="522" width="220" height="38" rx="5"/>
+    <text class="repo-name" x="320" y="537" text-anchor="middle">cc-recursive-team</text>
+    <text class="repo-desc" x="320" y="551" text-anchor="middle">recursive agent spawning</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/liminal-flux-gh-acc">
+    <title>liminal-flux — Self-evolving agent-operated GitHub account (Lim Sid)</title>
+    <rect class="box" x="470" y="522" width="220" height="38" rx="5"/>
+    <text class="repo-name" x="580" y="537" text-anchor="middle">liminal-flux</text>
+    <text class="repo-desc" x="580" y="551" text-anchor="middle">agent-operated GH account</text>
+  </a>
+
   <!-- Footer -->
-  <text class="note" x="20" y="518">* pat-tax/ org</text>
-  <text class="note" x="880" y="518" text-anchor="end">23 repositories</text>
+  <text class="note" x="20" y="586">* pat-tax/ org</text>
+  <text class="note" x="880" y="586" text-anchor="end">23 repositories</text>
 </svg>

--- a/assets/images/architecture.svg
+++ b/assets/images/architecture.svg
@@ -79,57 +79,50 @@
     <text class="repo-desc" x="815" y="90" text-anchor="middle">WakaTime correlation</text>
   </a>
 
-  <!-- ===== Layer 2: Agent Development Tooling (7 boxes, w=112, gap=10, start=28) ===== -->
+  <!-- ===== Layer 2: Agent Development Tooling (6 boxes, w=134, gap=12, start=18) ===== -->
   <rect class="layer-bg" x="10" y="118" width="880" height="74" rx="6"/>
   <text class="layer-label" x="20" y="132">AGENT DEVELOPMENT TOOLING</text>
 
   <a xlink:href="https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template">
     <title>ralph-loop template — Autonomous development loop with Claude Code</title>
-    <rect class="box" x="28" y="136" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="84" y="155" text-anchor="middle">ralph-loop</text>
-    <text class="repo-desc" x="84" y="170" text-anchor="middle">autonomous dev loop</text>
+    <rect class="box" x="18" y="136" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="85" y="155" text-anchor="middle">ralph-loop template</text>
+    <text class="repo-desc" x="85" y="170" text-anchor="middle">autonomous dev loop</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/claude-code-utils-plugin">
     <title>claude-code-utils-plugin — CC plugin marketplace with skills and rules</title>
-    <rect class="box" x="150" y="136" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="206" y="155" text-anchor="middle">cc-utils-plugin</text>
-    <text class="repo-desc" x="206" y="170" text-anchor="middle">plugins &amp; skills</text>
+    <rect class="box" x="164" y="136" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="231" y="155" text-anchor="middle">cc-utils-plugin</text>
+    <text class="repo-desc" x="231" y="170" text-anchor="middle">plugins &amp; skills</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/cc-recursive-team-mode">
     <title>cc-recursive-team-mode — Claude Code subprocess wrapper and artifact parser</title>
-    <rect class="box" x="272" y="136" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="328" y="155" text-anchor="middle">cc-recursive-team</text>
-    <text class="repo-desc" x="328" y="170" text-anchor="middle">CC subprocess wrapper</text>
+    <rect class="box" x="310" y="136" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="377" y="155" text-anchor="middle">cc-recursive-team</text>
+    <text class="repo-desc" x="377" y="170" text-anchor="middle">CC subprocess wrapper</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/polyforge">
     <title>polyforge — Multi-repo AI agent orchestration</title>
-    <rect class="box" x="394" y="136" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="450" y="155" text-anchor="middle">polyforge</text>
-    <text class="repo-desc" x="450" y="170" text-anchor="middle">multi-repo orchestration</text>
+    <rect class="box" x="456" y="136" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="523" y="155" text-anchor="middle">polyforge</text>
+    <text class="repo-desc" x="523" y="170" text-anchor="middle">multi-repo orchestration</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/CABIO-test">
     <title>CABIO-test — Context-Aware Business Intelligence Orchestration</title>
-    <rect class="box" x="516" y="136" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="572" y="155" text-anchor="middle">CABIO-test</text>
-    <text class="repo-desc" x="572" y="170" text-anchor="middle">business workflows</text>
+    <rect class="box" x="602" y="136" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="669" y="155" text-anchor="middle">CABIO-test</text>
+    <text class="repo-desc" x="669" y="170" text-anchor="middle">business orchestration</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/coding-agents-research">
     <title>coding-agents-research — Claude Code field research and feature analysis</title>
-    <rect class="box" x="638" y="136" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="694" y="155" text-anchor="middle">agents-research</text>
-    <text class="repo-desc" x="694" y="170" text-anchor="middle">Claude Code research</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/sdlc-lcm-manager">
-    <title>sdlc-lcm-manager — SDLC lifecycle management and tracking</title>
-    <rect class="box" x="760" y="136" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="816" y="155" text-anchor="middle">sdlc-lcm-manager</text>
-    <text class="repo-desc" x="816" y="170" text-anchor="middle">lifecycle management</text>
+    <rect class="box" x="748" y="136" width="134" height="48" rx="5"/>
+    <text class="repo-name" x="815" y="155" text-anchor="middle">coding-agents-research</text>
+    <text class="repo-desc" x="815" y="170" text-anchor="middle">Claude Code research</text>
   </a>
 
   <!-- ===== Layer 3: Agent Applications (3 boxes, w=220, gap=30, start=90) ===== -->
@@ -241,5 +234,5 @@
 
   <!-- Footer -->
   <text class="note" x="20" y="518">* pat-tax/ org</text>
-  <text class="note" x="880" y="518" text-anchor="end">24 repositories</text>
+  <text class="note" x="880" y="518" text-anchor="end">23 repositories</text>
 </svg>

--- a/assets/images/interconnections.svg
+++ b/assets/images/interconnections.svg
@@ -1,18 +1,22 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 860 370" width="860" height="370">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 860 500" width="860" height="500">
   <defs>
     <style>
+      /* Light mode (default) */
       .page-bg { fill: #ffffff; }
       .box { fill: #ffffff; stroke: #d0d7de; stroke-width: 1; rx: 5; }
       .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; font-weight: 700; fill: #1f2328; }
+      .layer-label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 10px; font-weight: 600; fill: #57606a; letter-spacing: 1.5px; }
       .repo-name { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 600; fill: #1f2328; }
       .repo-desc { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 9px; fill: #656d76; }
       .legend-label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 9px; fill: #656d76; }
       a:hover .box { stroke: #1f2328; stroke-width: 1.5; }
 
+      /* Dark mode */
       @media (prefers-color-scheme: dark) {
         .page-bg { fill: #0d1117; }
         .box { fill: #0d1117; stroke: #30363d; }
         .title { fill: #e6edf3; }
+        .layer-label { fill: #8b949e; }
         .repo-name { fill: #e6edf3; }
         .repo-desc { fill: #8b949e; }
         .legend-label { fill: #8b949e; }
@@ -34,140 +38,149 @@
     </marker>
   </defs>
 
-  <rect class="page-bg" width="860" height="370" rx="8"/>
-  <text class="title" x="430" y="24" text-anchor="middle">Repo Interconnections</text>
+  <rect class="page-bg" width="860" height="500" rx="8"/>
+  <text class="title" x="430" y="24" text-anchor="middle">Agentic Lifecycle Orchestration</text>
 
-  <!-- ===== Row 1: Research + Evaluation (y=50) ===== -->
-  <!-- 4 boxes: Agents-eval (left), coding-agents-research (center-left), coding-agent-eval (center-right), multi-tasking-quality (right) -->
-  <!-- w=175, gap=20. Total: 4*175+3*20=760. Start: (860-760)/2=50 -->
+  <!-- ===== Row A: Hands-off E2E Coding (1 box, centered) ===== -->
+  <!-- w=200, center at 430. Box: x=330 -->
+  <text class="layer-label" x="50" y="55">HANDS-OFF E2E CODING</text>
 
-  <a xlink:href="https://github.com/qte77/Agents-eval">
-    <rect class="box" x="50" y="50" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="138" y="70" text-anchor="middle">Agents-eval</text>
-    <text class="repo-desc" x="138" y="85" text-anchor="middle">3-tier MAS evaluation</text>
+  <a xlink:href="https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template">
+    <rect class="box" x="330" y="42" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="430" y="62" text-anchor="middle">ralph-loop template</text>
+    <text class="repo-desc" x="430" y="77" text-anchor="middle">autonomous dev loop</text>
+  </a>
+
+  <!-- ===== Row B: Project / Product / Company Steering (2 boxes) ===== -->
+  <!-- w=200, gap=40. Total=440. start=(860-440)/2=210. Boxes: 210, 450. Centers: 310, 550 -->
+  <text class="layer-label" x="50" y="130">PROJECT / PRODUCT STEERING</text>
+
+  <a xlink:href="https://github.com/qte77/CABIO-test">
+    <rect class="box" x="210" y="137" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="310" y="157" text-anchor="middle">CABIO-test</text>
+    <text class="repo-desc" x="310" y="172" text-anchor="middle">business orchestration</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/sdlc-lcm-manager">
+    <rect class="box" x="450" y="137" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="550" y="157" text-anchor="middle">sdlc-lcm-manager</text>
+    <text class="repo-desc" x="550" y="172" text-anchor="middle">SDLC lifecycle tracking</text>
+  </a>
+
+  <!-- ===== Row C: Multi-Repo Orchestration (2 boxes) ===== -->
+  <!-- w=200, gap=40. start=210. Boxes: 210, 450. Centers: 310, 550 -->
+  <text class="layer-label" x="50" y="225">MULTI-REPO ORCHESTRATION</text>
+
+  <a xlink:href="https://github.com/qte77/polyforge">
+    <rect class="box" x="210" y="232" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="310" y="252" text-anchor="middle">polyforge</text>
+    <text class="repo-desc" x="310" y="267" text-anchor="middle">parallel multi-repo work</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/gha-cross-repo-issue-sync">
+    <rect class="box" x="450" y="232" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="550" y="252" text-anchor="middle">cross-repo-issue-sync</text>
+    <text class="repo-desc" x="550" y="267" text-anchor="middle">issue synchronization</text>
+  </a>
+
+  <!-- ===== Row D: Research & Evaluation (3 boxes) ===== -->
+  <!-- w=175, gap=20. Total=565. start=(860-565)/2=148. Boxes: 148, 343, 538. Centers: 235, 430, 625 -->
+  <text class="layer-label" x="50" y="320">RESEARCH &amp; EVALUATION</text>
+
+  <a xlink:href="https://github.com/qte77/coding-agent-eval">
+    <rect class="box" x="148" y="327" width="175" height="48" rx="5"/>
+    <text class="repo-name" x="235" y="347" text-anchor="middle">coding-agent-eval</text>
+    <text class="repo-desc" x="235" y="362" text-anchor="middle">agent evaluation harness</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/coding-agents-research">
-    <rect class="box" x="245" y="50" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="333" y="70" text-anchor="middle">coding-agents-research</text>
-    <text class="repo-desc" x="333" y="85" text-anchor="middle">CC field research</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/coding-agent-eval">
-    <rect class="box" x="440" y="50" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="528" y="70" text-anchor="middle">coding-agent-eval</text>
-    <text class="repo-desc" x="528" y="85" text-anchor="middle">CC evaluation harness</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/multi-tasking-quality-benchmark">
-    <rect class="box" x="635" y="50" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="723" y="70" text-anchor="middle">multi-tasking-quality</text>
-    <text class="repo-desc" x="723" y="85" text-anchor="middle">WakaTime correlation</text>
-  </a>
-
-  <!-- ===== Row 2: Tooling (y=160) ===== -->
-  <!-- 3 boxes: ralph-loop, cc-utils-plugin, cc-recursive-team. w=175, gap=20. Total: 565. Start: 148 -->
-
-  <a xlink:href="https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template">
-    <rect class="box" x="148" y="160" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="235" y="180" text-anchor="middle">ralph-loop template</text>
-    <text class="repo-desc" x="235" y="195" text-anchor="middle">autonomous dev loop</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/claude-code-utils-plugin">
-    <rect class="box" x="343" y="160" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="430" y="180" text-anchor="middle">cc-utils-plugin</text>
-    <text class="repo-desc" x="430" y="195" text-anchor="middle">plugins &amp; skills</text>
+    <rect class="box" x="343" y="327" width="175" height="48" rx="5"/>
+    <text class="repo-name" x="430" y="347" text-anchor="middle">coding-agents-research</text>
+    <text class="repo-desc" x="430" y="362" text-anchor="middle">CC field research</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/cc-recursive-team-mode">
-    <rect class="box" x="538" y="160" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="625" y="180" text-anchor="middle">cc-recursive-team</text>
-    <text class="repo-desc" x="625" y="195" text-anchor="middle">CC subprocess wrapper</text>
+    <rect class="box" x="538" y="327" width="175" height="48" rx="5"/>
+    <text class="repo-name" x="625" y="347" text-anchor="middle">cc-recursive-team</text>
+    <text class="repo-desc" x="625" y="362" text-anchor="middle">recursive agent spawning</text>
   </a>
 
-  <!-- ===== Row 3: Orchestration (y=270) ===== -->
-  <!-- 3 boxes: market-research, polyforge, CABIO. w=175, gap=20. Total: 565. Start: 148 -->
+  <!-- ===== Row E: Helpers & Infrastructure (2 boxes) ===== -->
+  <!-- w=200, gap=40. start=210. Boxes: 210, 450. Centers: 310, 550 -->
+  <text class="layer-label" x="50" y="415">HELPERS &amp; INFRASTRUCTURE</text>
 
-  <a xlink:href="https://github.com/qte77/agentic-market-research-to-gtm">
-    <rect class="box" x="148" y="270" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="235" y="290" text-anchor="middle">market-research-to-gtm</text>
-    <text class="repo-desc" x="235" y="305" text-anchor="middle">AI market research</text>
+  <a xlink:href="https://github.com/qte77/dotfiles">
+    <rect class="box" x="210" y="422" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="310" y="442" text-anchor="middle">dotfiles</text>
+    <text class="repo-desc" x="310" y="457" text-anchor="middle">dev environment config</text>
   </a>
 
-  <a xlink:href="https://github.com/qte77/polyforge">
-    <rect class="box" x="343" y="270" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="430" y="290" text-anchor="middle">polyforge</text>
-    <text class="repo-desc" x="430" y="305" text-anchor="middle">multi-repo orchestration</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/CABIO-test">
-    <rect class="box" x="538" y="270" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="625" y="290" text-anchor="middle">CABIO-test</text>
-    <text class="repo-desc" x="625" y="305" text-anchor="middle">business workflows</text>
+  <a xlink:href="https://github.com/qte77/claude-code-utils-plugin">
+    <rect class="box" x="450" y="422" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="550" y="442" text-anchor="middle">cc-utils-plugin</text>
+    <text class="repo-desc" x="550" y="457" text-anchor="middle">plugins &amp; skills</text>
   </a>
 
   <!-- ===== Arrows ===== -->
+  <!-- Blue: uses / scales via -->
+  <!-- Green: configures / bootstraps -->
+  <!-- Orange: creates / syncs -->
+  <!-- Purple: feeds back into -->
 
-  <!-- Blue: uses / depends on -->
-  <!-- Green: runs inside -->
-  <!-- Orange: creates / updates -->
-  <!-- Purple: feeds research into -->
+  <!-- 1. ralph-loop → CABIO-test (drives) -->
+  <!-- From ralph bottom-left (380,90) to CABIO top (310,137) -->
+  <path d="M 380,90 C 360,110 330,125 310,137" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
 
-  <!-- 1. Agents-eval → ralph-loop (submodule) -->
-  <!-- From (138,98) down to (235,160) — diagonal through open space -->
-  <path d="M 138,98 L 235,160" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
+  <!-- 2. ralph-loop → sdlc-lcm-manager (tracks via) -->
+  <!-- From ralph bottom-right (480,90) to sdlc top (550,137) -->
+  <path d="M 480,90 C 500,110 530,125 550,137" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
 
-  <!-- 2. Agents-eval → cc-utils-plugin (uses) -->
-  <!-- From (180,98) curving right-down to (430,160) — open space between R1 and R2 -->
-  <path d="M 180,98 C 280,130 380,150 430,160" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
+  <!-- 3. ralph-loop → polyforge (scales via) -->
+  <!-- From ralph bottom (430,90) curving down to polyforge top (310,232) -->
+  <path d="M 430,90 C 430,150 350,200 310,232" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
 
-  <!-- 3. coding-agent-eval → cc-recursive-team (depends on) -->
-  <!-- From (528,98) down to (625,160) — diagonal through open space -->
-  <path d="M 545,98 L 625,160" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
+  <!-- 4. CABIO-test → sdlc-lcm-manager (feeds lifecycle) -->
+  <!-- Short horizontal right from CABIO right (410,161) to sdlc left (450,161) -->
+  <path d="M 410,161 L 450,161" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
 
-  <!-- 4. coding-agent-eval → coding-agents-research (submodule) -->
-  <!-- Short horizontal left from (440,74) to (420,74) -->
-  <path d="M 440,74 L 420,74" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
+  <!-- 5. polyforge → cross-repo-issue-sync (creates issues) -->
+  <!-- Short horizontal right from polyforge right (410,256) to sync left (450,256) -->
+  <path d="M 410,256 L 450,256" fill="none" stroke="#d29922" stroke-width="1.5" marker-end="url(#a-orange)"/>
 
-  <!-- 5. ralph → cc-utils-plugin (uses skills) -->
-  <!-- Short horizontal right from (323,184) to (343,184) -->
-  <path d="M 323,184 L 343,184" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
+  <!-- 6. coding-agent-eval → ralph-loop (eval improves) -->
+  <!-- From eval top (235,327) curving up-right to ralph bottom-left (370,90) -->
+  <path d="M 235,327 C 200,250 280,130 370,90" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
 
-  <!-- 6. coding-agents-research → coding-agent-eval (feeds research) -->
-  <!-- Short horizontal right from (420,65) to (440,65) — parallel to arrow 4, offset vertically -->
-  <path d="M 420,65 L 440,65" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
+  <!-- 7. coding-agents-research → cc-utils-plugin (research improves) -->
+  <!-- From research bottom (430,375) curving down to plugin top (550,422) -->
+  <path d="M 430,375 C 460,395 520,410 550,422" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
 
-  <!-- 7. coding-agents-research → multi-tasking-quality (feeds research) -->
-  <!-- From research top-right (420,55) arcing above coding-agent-eval to multi-tasking top-left (635,55) -->
-  <path d="M 420,55 C 480,30 580,30 635,55" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
+  <!-- 8. cc-recursive-team → coding-agent-eval (feeds eval) -->
+  <!-- Short horizontal left from recursive left (538,351) to eval right (323,351) -->
+  <path d="M 538,351 L 323,351" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
 
-  <!-- 8. ralph → polyforge (runs inside) -->
-  <!-- From ralph bottom (235,208) to polyforge top (430,270) — diagonal through open space -->
-  <path d="M 260,208 C 310,240 390,260 430,270" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
+  <!-- 9. dotfiles → ralph-loop (bootstraps) -->
+  <!-- From dotfiles top (310,422) curving up to ralph bottom-left (350,90) -->
+  <path d="M 310,422 C 280,320 300,150 350,90" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
 
-  <!-- 9. CABIO → polyforge (runs inside) -->
-  <!-- Short horizontal left from CABIO left (538,294) to polyforge right (518,294) -->
-  <path d="M 538,294 L 518,294" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
+  <!-- 10. cc-utils-plugin → ralph-loop (configures) -->
+  <!-- From plugin top (550,422) curving up to ralph bottom-right (500,90) -->
+  <path d="M 550,422 C 580,320 540,150 500,90" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
 
-  <!-- 10. market-research → polyforge (runs inside) -->
-  <!-- Short horizontal right from market right (323,294) to polyforge left (343,294) -->
-  <path d="M 323,294 L 343,294" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
-
-  <!-- 11. ralph → CABIO (creates/updates) -->
-  <!-- From ralph bottom-right (290,208) curving right-down to CABIO top (625,270) — open space -->
-  <path d="M 290,208 C 400,240 560,260 625,270" fill="none" stroke="#d29922" stroke-width="1.5" marker-end="url(#a-orange)"/>
+  <!-- 11. cross-repo-issue-sync → sdlc-lcm-manager (syncs to) -->
+  <!-- From sync top (550,232) curving up to sdlc bottom (550,185) -->
+  <path d="M 550,232 L 550,185" fill="none" stroke="#d29922" stroke-width="1.5" marker-end="url(#a-orange)"/>
 
   <!-- ===== Legend ===== -->
-  <line x1="120" y1="345" x2="150" y2="345" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
-  <text class="legend-label" x="158" y="349">uses / depends on</text>
+  <line x1="100" y1="488" x2="130" y2="488" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
+  <text class="legend-label" x="138" y="492">uses / scales via</text>
 
-  <line x1="300" y1="345" x2="330" y2="345" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
-  <text class="legend-label" x="338" y="349">runs inside</text>
+  <line x1="280" y1="488" x2="310" y2="488" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
+  <text class="legend-label" x="318" y="492">configures / bootstraps</text>
 
-  <line x1="440" y1="345" x2="470" y2="345" stroke="#d29922" stroke-width="1.5" marker-end="url(#a-orange)"/>
-  <text class="legend-label" x="478" y="349">creates / updates</text>
+  <line x1="470" y1="488" x2="500" y2="488" stroke="#d29922" stroke-width="1.5" marker-end="url(#a-orange)"/>
+  <text class="legend-label" x="508" y="492">creates / syncs</text>
 
-  <line x1="600" y1="345" x2="630" y2="345" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
-  <text class="legend-label" x="638" y="349">feeds research</text>
+  <line x1="630" y1="488" x2="660" y2="488" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
+  <text class="legend-label" x="668" y="492">feeds back into</text>
 </svg>

--- a/assets/images/interconnections.svg
+++ b/assets/images/interconnections.svg
@@ -36,45 +36,45 @@
   <text class="title" x="430" y="20" text-anchor="middle">Hands-off Agentic Lifecycle Management</text>
   <text class="subtitle" x="430" y="36" text-anchor="middle">Multi-repo orchestration — agents code, steer, scale, and improve autonomously</text>
 
-  <!-- ===== Layer 1: Autonomous Coding (1 box, centered) ===== -->
+  <!-- ===== Layer 1: Product & Business Steering (1 box, centered) ===== -->
   <rect class="layer-bg" x="10" y="48" width="840" height="74" rx="6"/>
-  <text class="layer-label" x="20" y="62">AUTONOMOUS CODING</text>
-
-  <a xlink:href="https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template">
-    <title>ralph-loop template — Autonomous development loop with Claude Code, TDD, and kanban</title>
-    <rect class="box" x="330" y="66" width="200" height="48" rx="5"/>
-    <text class="repo-name" x="430" y="85" text-anchor="middle">ralph-loop template</text>
-    <text class="repo-desc" x="430" y="100" text-anchor="middle">hands-off e2e dev loop</text>
-  </a>
-
-  <!-- ===== Layer 2: Product & Business Steering (1 box, centered) ===== -->
-  <rect class="layer-bg" x="10" y="128" width="840" height="74" rx="6"/>
-  <text class="layer-label" x="20" y="142">PRODUCT &amp; BUSINESS STEERING</text>
+  <text class="layer-label" x="20" y="62">PRODUCT &amp; BUSINESS STEERING</text>
 
   <a xlink:href="https://github.com/qte77/CABIO-test">
     <title>CABIO-test — Context-Aware Business Intelligence Orchestration and lifecycle management</title>
-    <rect class="box" x="330" y="146" width="200" height="48" rx="5"/>
-    <text class="repo-name" x="430" y="165" text-anchor="middle">CABIO-test</text>
-    <text class="repo-desc" x="430" y="180" text-anchor="middle">business &amp; lifecycle mgmt</text>
+    <rect class="box" x="330" y="66" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="430" y="85" text-anchor="middle">CABIO-test</text>
+    <text class="repo-desc" x="430" y="100" text-anchor="middle">business &amp; lifecycle mgmt</text>
   </a>
 
-  <!-- ===== Layer 3: Multi-Repo Orchestration (2 boxes) ===== -->
+  <!-- ===== Layer 2: Multi-Repo Orchestration (2 boxes) ===== -->
   <!-- w=200, gap=40. Total=440. start=(840-440)/2+10=210. Boxes: 210, 450. Centers: 310, 550 -->
-  <rect class="layer-bg" x="10" y="208" width="840" height="74" rx="6"/>
-  <text class="layer-label" x="20" y="222">MULTI-REPO ORCHESTRATION</text>
+  <rect class="layer-bg" x="10" y="128" width="840" height="74" rx="6"/>
+  <text class="layer-label" x="20" y="142">MULTI-REPO ORCHESTRATION</text>
 
   <a xlink:href="https://github.com/qte77/polyforge">
     <title>polyforge — Polyrepo dev forge for parallel AI agent workflows across multiple repositories</title>
-    <rect class="box" x="210" y="226" width="200" height="48" rx="5"/>
-    <text class="repo-name" x="310" y="245" text-anchor="middle">polyforge</text>
-    <text class="repo-desc" x="310" y="260" text-anchor="middle">parallel multi-repo work</text>
+    <rect class="box" x="210" y="146" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="310" y="165" text-anchor="middle">polyforge</text>
+    <text class="repo-desc" x="310" y="180" text-anchor="middle">parallel multi-repo work</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-cross-repo-issue-sync">
     <title>gha-cross-repo-issue-sync — Bidirectional issue synchronization across repositories</title>
-    <rect class="box" x="450" y="226" width="200" height="48" rx="5"/>
-    <text class="repo-name" x="550" y="245" text-anchor="middle">cross-repo-issue-sync</text>
-    <text class="repo-desc" x="550" y="260" text-anchor="middle">issue synchronization</text>
+    <rect class="box" x="450" y="146" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="550" y="165" text-anchor="middle">cross-repo-issue-sync</text>
+    <text class="repo-desc" x="550" y="180" text-anchor="middle">issue synchronization</text>
+  </a>
+
+  <!-- ===== Layer 3: Autonomous Coding (1 box, centered) ===== -->
+  <rect class="layer-bg" x="10" y="208" width="840" height="74" rx="6"/>
+  <text class="layer-label" x="20" y="222">AUTONOMOUS CODING</text>
+
+  <a xlink:href="https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template">
+    <title>ralph-loop template — Autonomous development loop with Claude Code, TDD, and kanban</title>
+    <rect class="box" x="330" y="226" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="430" y="245" text-anchor="middle">ralph-loop template</text>
+    <text class="repo-desc" x="430" y="260" text-anchor="middle">hands-off e2e dev loop</text>
   </a>
 
   <!-- ===== Layer 4: Agent Research & Evaluation (3 boxes) ===== -->

--- a/assets/images/interconnections.svg
+++ b/assets/images/interconnections.svg
@@ -1,172 +1,127 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 860 500" width="860" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 860 468" width="860" height="468">
   <defs>
     <style>
       /* Light mode (default) */
       .page-bg { fill: #ffffff; }
-      .box { fill: #ffffff; stroke: #d0d7de; stroke-width: 1; rx: 5; }
-      .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 14px; font-weight: 700; fill: #1f2328; }
+      .layer-bg { fill: #f6f8fa; }
+      .box { fill: #ffffff; stroke: #d0d7de; stroke-width: 1; }
+      .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 15px; font-weight: 700; fill: #1f2328; }
+      .subtitle { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; fill: #656d76; }
       .layer-label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 10px; font-weight: 600; fill: #57606a; letter-spacing: 1.5px; }
       .repo-name { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 600; fill: #1f2328; }
       .repo-desc { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 9px; fill: #656d76; }
-      .legend-label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 9px; fill: #656d76; }
+      .note { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 9px; fill: #8b949e; }
       a:hover .box { stroke: #1f2328; stroke-width: 1.5; }
 
       /* Dark mode */
       @media (prefers-color-scheme: dark) {
         .page-bg { fill: #0d1117; }
+        .layer-bg { fill: #161b22; }
         .box { fill: #0d1117; stroke: #30363d; }
         .title { fill: #e6edf3; }
+        .subtitle { fill: #8b949e; }
         .layer-label { fill: #8b949e; }
         .repo-name { fill: #e6edf3; }
         .repo-desc { fill: #8b949e; }
-        .legend-label { fill: #8b949e; }
+        .note { fill: #484f58; }
         a:hover .box { stroke: #e6edf3; }
       }
     </style>
-
-    <marker id="a-blue" viewBox="0 0 10 6" refX="10" refY="3" markerWidth="8" markerHeight="5" orient="auto">
-      <path d="M0,0 L10,3 L0,6 Z" fill="#4493f8"/>
-    </marker>
-    <marker id="a-green" viewBox="0 0 10 6" refX="10" refY="3" markerWidth="8" markerHeight="5" orient="auto">
-      <path d="M0,0 L10,3 L0,6 Z" fill="#3fb950"/>
-    </marker>
-    <marker id="a-orange" viewBox="0 0 10 6" refX="10" refY="3" markerWidth="8" markerHeight="5" orient="auto">
-      <path d="M0,0 L10,3 L0,6 Z" fill="#d29922"/>
-    </marker>
-    <marker id="a-purple" viewBox="0 0 10 6" refX="10" refY="3" markerWidth="8" markerHeight="5" orient="auto">
-      <path d="M0,0 L10,3 L0,6 Z" fill="#a371f7"/>
-    </marker>
   </defs>
 
-  <rect class="page-bg" width="860" height="500" rx="8"/>
-  <text class="title" x="430" y="24" text-anchor="middle">Agentic Lifecycle Orchestration</text>
+  <!-- Page background -->
+  <rect class="page-bg" width="860" height="468" rx="8"/>
 
-  <!-- ===== Row A: Hands-off E2E Coding (1 box, centered) ===== -->
-  <!-- w=200, center at 430. Box: x=330 -->
-  <text class="layer-label" x="50" y="55">HANDS-OFF E2E CODING</text>
+  <!-- Title + subtitle -->
+  <text class="title" x="430" y="20" text-anchor="middle">Hands-off Agentic Lifecycle Management</text>
+  <text class="subtitle" x="430" y="36" text-anchor="middle">Multi-repo orchestration — agents code, steer, scale, and improve autonomously</text>
+
+  <!-- ===== Layer 1: Autonomous Coding (1 box, centered) ===== -->
+  <rect class="layer-bg" x="10" y="48" width="840" height="74" rx="6"/>
+  <text class="layer-label" x="20" y="62">AUTONOMOUS CODING</text>
 
   <a xlink:href="https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template">
-    <rect class="box" x="330" y="42" width="200" height="48" rx="5"/>
-    <text class="repo-name" x="430" y="62" text-anchor="middle">ralph-loop template</text>
-    <text class="repo-desc" x="430" y="77" text-anchor="middle">autonomous dev loop</text>
+    <title>ralph-loop template — Autonomous development loop with Claude Code, TDD, and kanban</title>
+    <rect class="box" x="330" y="66" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="430" y="85" text-anchor="middle">ralph-loop template</text>
+    <text class="repo-desc" x="430" y="100" text-anchor="middle">hands-off e2e dev loop</text>
   </a>
 
-  <!-- ===== Row B: Project / Product / Company Steering (1 box, centered) ===== -->
-  <!-- w=200, center at 430. Box: x=330 -->
-  <text class="layer-label" x="50" y="130">PROJECT / PRODUCT STEERING</text>
+  <!-- ===== Layer 2: Product & Business Steering (1 box, centered) ===== -->
+  <rect class="layer-bg" x="10" y="128" width="840" height="74" rx="6"/>
+  <text class="layer-label" x="20" y="142">PRODUCT &amp; BUSINESS STEERING</text>
 
   <a xlink:href="https://github.com/qte77/CABIO-test">
-    <rect class="box" x="330" y="137" width="200" height="48" rx="5"/>
-    <text class="repo-name" x="430" y="157" text-anchor="middle">CABIO-test</text>
-    <text class="repo-desc" x="430" y="172" text-anchor="middle">business &amp; lifecycle mgmt</text>
+    <title>CABIO-test — Context-Aware Business Intelligence Orchestration and lifecycle management</title>
+    <rect class="box" x="330" y="146" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="430" y="165" text-anchor="middle">CABIO-test</text>
+    <text class="repo-desc" x="430" y="180" text-anchor="middle">business &amp; lifecycle mgmt</text>
   </a>
 
-  <!-- ===== Row C: Multi-Repo Orchestration (2 boxes) ===== -->
-  <!-- w=200, gap=40. start=210. Boxes: 210, 450. Centers: 310, 550 -->
-  <text class="layer-label" x="50" y="225">MULTI-REPO ORCHESTRATION</text>
+  <!-- ===== Layer 3: Multi-Repo Orchestration (2 boxes) ===== -->
+  <!-- w=200, gap=40. Total=440. start=(840-440)/2+10=210. Boxes: 210, 450. Centers: 310, 550 -->
+  <rect class="layer-bg" x="10" y="208" width="840" height="74" rx="6"/>
+  <text class="layer-label" x="20" y="222">MULTI-REPO ORCHESTRATION</text>
 
   <a xlink:href="https://github.com/qte77/polyforge">
-    <rect class="box" x="210" y="232" width="200" height="48" rx="5"/>
-    <text class="repo-name" x="310" y="252" text-anchor="middle">polyforge</text>
-    <text class="repo-desc" x="310" y="267" text-anchor="middle">parallel multi-repo work</text>
+    <title>polyforge — Polyrepo dev forge for parallel AI agent workflows across multiple repositories</title>
+    <rect class="box" x="210" y="226" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="310" y="245" text-anchor="middle">polyforge</text>
+    <text class="repo-desc" x="310" y="260" text-anchor="middle">parallel multi-repo work</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-cross-repo-issue-sync">
-    <rect class="box" x="450" y="232" width="200" height="48" rx="5"/>
-    <text class="repo-name" x="550" y="252" text-anchor="middle">cross-repo-issue-sync</text>
-    <text class="repo-desc" x="550" y="267" text-anchor="middle">issue synchronization</text>
+    <title>gha-cross-repo-issue-sync — Bidirectional issue synchronization across repositories</title>
+    <rect class="box" x="450" y="226" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="550" y="245" text-anchor="middle">cross-repo-issue-sync</text>
+    <text class="repo-desc" x="550" y="260" text-anchor="middle">issue synchronization</text>
   </a>
 
-  <!-- ===== Row D: Research & Evaluation (3 boxes) ===== -->
-  <!-- w=175, gap=20. Total=565. start=(860-565)/2=148. Boxes: 148, 343, 538. Centers: 235, 430, 625 -->
-  <text class="layer-label" x="50" y="320">RESEARCH &amp; EVALUATION</text>
+  <!-- ===== Layer 4: Agent Research & Evaluation (3 boxes) ===== -->
+  <!-- w=175, gap=20. Total=565. start=(840-565)/2+10=148. Boxes: 148, 343, 538. Centers: 235, 430, 625 -->
+  <rect class="layer-bg" x="10" y="288" width="840" height="74" rx="6"/>
+  <text class="layer-label" x="20" y="302">AGENT RESEARCH &amp; EVALUATION</text>
 
   <a xlink:href="https://github.com/qte77/coding-agent-eval">
-    <rect class="box" x="148" y="327" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="235" y="347" text-anchor="middle">coding-agent-eval</text>
-    <text class="repo-desc" x="235" y="362" text-anchor="middle">agent evaluation harness</text>
+    <title>coding-agent-eval — Hands-off coding agent comparison harness</title>
+    <rect class="box" x="148" y="306" width="175" height="48" rx="5"/>
+    <text class="repo-name" x="235" y="325" text-anchor="middle">coding-agent-eval</text>
+    <text class="repo-desc" x="235" y="340" text-anchor="middle">agent evaluation harness</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/coding-agents-research">
-    <rect class="box" x="343" y="327" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="430" y="347" text-anchor="middle">coding-agents-research</text>
-    <text class="repo-desc" x="430" y="362" text-anchor="middle">CC field research</text>
+    <title>coding-agents-research — Field research and feature analysis for Claude Code</title>
+    <rect class="box" x="343" y="306" width="175" height="48" rx="5"/>
+    <text class="repo-name" x="430" y="325" text-anchor="middle">coding-agents-research</text>
+    <text class="repo-desc" x="430" y="340" text-anchor="middle">CC field research</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/cc-recursive-team-mode">
-    <rect class="box" x="538" y="327" width="175" height="48" rx="5"/>
-    <text class="repo-name" x="625" y="347" text-anchor="middle">cc-recursive-team</text>
-    <text class="repo-desc" x="625" y="362" text-anchor="middle">recursive agent spawning</text>
+    <title>cc-recursive-team-mode — Claude Code subprocess wrapper, recursive spawning, and artifact parser</title>
+    <rect class="box" x="538" y="306" width="175" height="48" rx="5"/>
+    <text class="repo-name" x="625" y="325" text-anchor="middle">cc-recursive-team</text>
+    <text class="repo-desc" x="625" y="340" text-anchor="middle">recursive agent spawning</text>
   </a>
 
-  <!-- ===== Row E: Helpers & Infrastructure (2 boxes) ===== -->
+  <!-- ===== Layer 5: Tooling & Infrastructure (2 boxes) ===== -->
   <!-- w=200, gap=40. start=210. Boxes: 210, 450. Centers: 310, 550 -->
-  <text class="layer-label" x="50" y="415">HELPERS &amp; INFRASTRUCTURE</text>
+  <rect class="layer-bg" x="10" y="368" width="840" height="74" rx="6"/>
+  <text class="layer-label" x="20" y="382">TOOLING &amp; INFRASTRUCTURE</text>
 
   <a xlink:href="https://github.com/qte77/dotfiles">
-    <rect class="box" x="210" y="422" width="200" height="48" rx="5"/>
-    <text class="repo-name" x="310" y="442" text-anchor="middle">dotfiles</text>
-    <text class="repo-desc" x="310" y="457" text-anchor="middle">dev environment config</text>
+    <title>dotfiles — Personal dev environment config for Codespaces and devcontainers</title>
+    <rect class="box" x="210" y="386" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="310" y="405" text-anchor="middle">dotfiles</text>
+    <text class="repo-desc" x="310" y="420" text-anchor="middle">dev environment config</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/claude-code-utils-plugin">
-    <rect class="box" x="450" y="422" width="200" height="48" rx="5"/>
-    <text class="repo-name" x="550" y="442" text-anchor="middle">cc-utils-plugin</text>
-    <text class="repo-desc" x="550" y="457" text-anchor="middle">plugins &amp; skills</text>
+    <title>claude-code-utils-plugin — CC plugin marketplace with skills, rules, and scripts</title>
+    <rect class="box" x="450" y="386" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="550" y="405" text-anchor="middle">cc-utils-plugin</text>
+    <text class="repo-desc" x="550" y="420" text-anchor="middle">plugins &amp; skills</text>
   </a>
 
-  <!-- ===== Arrows ===== -->
-  <!-- Blue: uses / scales via -->
-  <!-- Green: configures / bootstraps -->
-  <!-- Orange: creates / syncs -->
-  <!-- Purple: feeds back into -->
-
-  <!-- 1. ralph-loop → CABIO-test (drives) -->
-  <!-- Straight vertical: ralph bottom center → CABIO top center -->
-  <path d="M 430,90 L 430,137" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
-
-  <!-- 2. ralph-loop → polyforge (scales via) -->
-  <!-- Route LEFT of CABIO (x<330): ralph left edge → curve left → polyforge top center -->
-  <path d="M 330,90 C 200,120 200,210 310,232" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
-
-  <!-- 3. polyforge → cross-repo-issue-sync (creates issues) -->
-  <!-- Horizontal gap between boxes: polyforge right → sync left -->
-  <path d="M 410,256 L 450,256" fill="none" stroke="#d29922" stroke-width="1.5" marker-end="url(#a-orange)"/>
-
-  <!-- 4. coding-agent-eval → ralph-loop (eval improves) -->
-  <!-- Route FAR LEFT (x≈100) to avoid polyforge + CABIO: eval left edge → far-left channel → ralph left edge -->
-  <path d="M 148,351 C 100,320 100,100 330,90" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
-
-  <!-- 5. coding-agents-research → cc-utils-plugin (research improves) -->
-  <!-- Diagonal down through gap between rows D and E -->
-  <path d="M 430,375 C 460,395 520,410 550,422" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
-
-  <!-- 6. cc-recursive-team → coding-agent-eval (feeds eval) -->
-  <!-- ARC ABOVE row D (y≈300) to avoid crossing research box -->
-  <path d="M 538,327 C 490,295 370,295 323,327" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
-
-  <!-- 7. dotfiles → ralph-loop (bootstraps) -->
-  <!-- Route FAR LEFT (x≈100) to avoid eval + polyforge + CABIO: dotfiles left edge → far-left → ralph left edge -->
-  <path d="M 210,446 C 100,400 100,90 330,90" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
-
-  <!-- 8. cc-utils-plugin → ralph-loop (configures) -->
-  <!-- Route FAR RIGHT (x≈760) to avoid recursive + cross-repo + CABIO: plugin right edge → far-right → ralph right edge -->
-  <path d="M 650,446 C 760,400 760,90 530,90" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
-
-  <!-- 9. cross-repo-issue-sync → CABIO-test (syncs to) -->
-  <!-- Diagonal up through gap between rows C and B: sync top → CABIO bottom-right -->
-  <path d="M 550,232 C 540,210 510,195 530,185" fill="none" stroke="#d29922" stroke-width="1.5" marker-end="url(#a-orange)"/>
-
-  <!-- ===== Legend ===== -->
-  <line x1="100" y1="488" x2="130" y2="488" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
-  <text class="legend-label" x="138" y="492">uses / scales via</text>
-
-  <line x1="280" y1="488" x2="310" y2="488" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
-  <text class="legend-label" x="318" y="492">configures / bootstraps</text>
-
-  <line x1="470" y1="488" x2="500" y2="488" stroke="#d29922" stroke-width="1.5" marker-end="url(#a-orange)"/>
-  <text class="legend-label" x="508" y="492">creates / syncs</text>
-
-  <line x1="630" y1="488" x2="660" y2="488" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
-  <text class="legend-label" x="668" y="492">feeds back into</text>
+  <!-- Footer -->
+  <text class="note" x="840" y="458" text-anchor="end">9 repositories — higher layers use lower layers</text>
 </svg>

--- a/assets/images/interconnections.svg
+++ b/assets/images/interconnections.svg
@@ -51,20 +51,14 @@
     <text class="repo-desc" x="430" y="77" text-anchor="middle">autonomous dev loop</text>
   </a>
 
-  <!-- ===== Row B: Project / Product / Company Steering (2 boxes) ===== -->
-  <!-- w=200, gap=40. Total=440. start=(860-440)/2=210. Boxes: 210, 450. Centers: 310, 550 -->
+  <!-- ===== Row B: Project / Product / Company Steering (1 box, centered) ===== -->
+  <!-- w=200, center at 430. Box: x=330 -->
   <text class="layer-label" x="50" y="130">PROJECT / PRODUCT STEERING</text>
 
   <a xlink:href="https://github.com/qte77/CABIO-test">
-    <rect class="box" x="210" y="137" width="200" height="48" rx="5"/>
-    <text class="repo-name" x="310" y="157" text-anchor="middle">CABIO-test</text>
-    <text class="repo-desc" x="310" y="172" text-anchor="middle">business orchestration</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/sdlc-lcm-manager">
-    <rect class="box" x="450" y="137" width="200" height="48" rx="5"/>
-    <text class="repo-name" x="550" y="157" text-anchor="middle">sdlc-lcm-manager</text>
-    <text class="repo-desc" x="550" y="172" text-anchor="middle">SDLC lifecycle tracking</text>
+    <rect class="box" x="330" y="137" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="430" y="157" text-anchor="middle">CABIO-test</text>
+    <text class="repo-desc" x="430" y="172" text-anchor="middle">business &amp; lifecycle mgmt</text>
   </a>
 
   <!-- ===== Row C: Multi-Repo Orchestration (2 boxes) ===== -->
@@ -128,48 +122,40 @@
   <!-- Purple: feeds back into -->
 
   <!-- 1. ralph-loop → CABIO-test (drives) -->
-  <!-- From ralph bottom-left (380,90) to CABIO top (310,137) -->
-  <path d="M 380,90 C 360,110 330,125 310,137" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
+  <!-- From ralph bottom (430,90) to CABIO top (430,137) -->
+  <path d="M 430,90 L 430,137" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
 
-  <!-- 2. ralph-loop → sdlc-lcm-manager (tracks via) -->
-  <!-- From ralph bottom-right (480,90) to sdlc top (550,137) -->
-  <path d="M 480,90 C 500,110 530,125 550,137" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
-
-  <!-- 3. ralph-loop → polyforge (scales via) -->
-  <!-- From ralph bottom (430,90) curving down to polyforge top (310,232) -->
-  <path d="M 430,90 C 430,150 350,200 310,232" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
-
-  <!-- 4. CABIO-test → sdlc-lcm-manager (feeds lifecycle) -->
-  <!-- Short horizontal right from CABIO right (410,161) to sdlc left (450,161) -->
-  <path d="M 410,161 L 450,161" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
+  <!-- 2. ralph-loop → polyforge (scales via) -->
+  <!-- From ralph bottom-left (380,90) curving down to polyforge top (310,232) -->
+  <path d="M 380,90 C 360,150 330,200 310,232" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
 
   <!-- 5. polyforge → cross-repo-issue-sync (creates issues) -->
   <!-- Short horizontal right from polyforge right (410,256) to sync left (450,256) -->
   <path d="M 410,256 L 450,256" fill="none" stroke="#d29922" stroke-width="1.5" marker-end="url(#a-orange)"/>
 
-  <!-- 6. coding-agent-eval → ralph-loop (eval improves) -->
+  <!-- 5. coding-agent-eval → ralph-loop (eval improves) -->
   <!-- From eval top (235,327) curving up-right to ralph bottom-left (370,90) -->
   <path d="M 235,327 C 200,250 280,130 370,90" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
 
-  <!-- 7. coding-agents-research → cc-utils-plugin (research improves) -->
+  <!-- 6. coding-agents-research → cc-utils-plugin (research improves) -->
   <!-- From research bottom (430,375) curving down to plugin top (550,422) -->
   <path d="M 430,375 C 460,395 520,410 550,422" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
 
-  <!-- 8. cc-recursive-team → coding-agent-eval (feeds eval) -->
+  <!-- 7. cc-recursive-team → coding-agent-eval (feeds eval) -->
   <!-- Short horizontal left from recursive left (538,351) to eval right (323,351) -->
   <path d="M 538,351 L 323,351" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
 
-  <!-- 9. dotfiles → ralph-loop (bootstraps) -->
+  <!-- 8. dotfiles → ralph-loop (bootstraps) -->
   <!-- From dotfiles top (310,422) curving up to ralph bottom-left (350,90) -->
   <path d="M 310,422 C 280,320 300,150 350,90" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
 
-  <!-- 10. cc-utils-plugin → ralph-loop (configures) -->
+  <!-- 9. cc-utils-plugin → ralph-loop (configures) -->
   <!-- From plugin top (550,422) curving up to ralph bottom-right (500,90) -->
   <path d="M 550,422 C 580,320 540,150 500,90" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
 
-  <!-- 11. cross-repo-issue-sync → sdlc-lcm-manager (syncs to) -->
-  <!-- From sync top (550,232) curving up to sdlc bottom (550,185) -->
-  <path d="M 550,232 L 550,185" fill="none" stroke="#d29922" stroke-width="1.5" marker-end="url(#a-orange)"/>
+  <!-- 10. cross-repo-issue-sync → CABIO-test (syncs to) -->
+  <!-- From sync top (550,232) curving up to CABIO bottom-right (490,185) -->
+  <path d="M 550,232 C 540,210 510,195 490,185" fill="none" stroke="#d29922" stroke-width="1.5" marker-end="url(#a-orange)"/>
 
   <!-- ===== Legend ===== -->
   <line x1="100" y1="488" x2="130" y2="488" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>

--- a/assets/images/interconnections.svg
+++ b/assets/images/interconnections.svg
@@ -122,40 +122,40 @@
   <!-- Purple: feeds back into -->
 
   <!-- 1. ralph-loop → CABIO-test (drives) -->
-  <!-- From ralph bottom (430,90) to CABIO top (430,137) -->
+  <!-- Straight vertical: ralph bottom center → CABIO top center -->
   <path d="M 430,90 L 430,137" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
 
   <!-- 2. ralph-loop → polyforge (scales via) -->
-  <!-- From ralph bottom-left (380,90) curving down to polyforge top (310,232) -->
-  <path d="M 380,90 C 360,150 330,200 310,232" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
+  <!-- Route LEFT of CABIO (x<330): ralph left edge → curve left → polyforge top center -->
+  <path d="M 330,90 C 200,120 200,210 310,232" fill="none" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>
 
-  <!-- 5. polyforge → cross-repo-issue-sync (creates issues) -->
-  <!-- Short horizontal right from polyforge right (410,256) to sync left (450,256) -->
+  <!-- 3. polyforge → cross-repo-issue-sync (creates issues) -->
+  <!-- Horizontal gap between boxes: polyforge right → sync left -->
   <path d="M 410,256 L 450,256" fill="none" stroke="#d29922" stroke-width="1.5" marker-end="url(#a-orange)"/>
 
-  <!-- 5. coding-agent-eval → ralph-loop (eval improves) -->
-  <!-- From eval top (235,327) curving up-right to ralph bottom-left (370,90) -->
-  <path d="M 235,327 C 200,250 280,130 370,90" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
+  <!-- 4. coding-agent-eval → ralph-loop (eval improves) -->
+  <!-- Route FAR LEFT (x≈100) to avoid polyforge + CABIO: eval left edge → far-left channel → ralph left edge -->
+  <path d="M 148,351 C 100,320 100,100 330,90" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
 
-  <!-- 6. coding-agents-research → cc-utils-plugin (research improves) -->
-  <!-- From research bottom (430,375) curving down to plugin top (550,422) -->
+  <!-- 5. coding-agents-research → cc-utils-plugin (research improves) -->
+  <!-- Diagonal down through gap between rows D and E -->
   <path d="M 430,375 C 460,395 520,410 550,422" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
 
-  <!-- 7. cc-recursive-team → coding-agent-eval (feeds eval) -->
-  <!-- Short horizontal left from recursive left (538,351) to eval right (323,351) -->
-  <path d="M 538,351 L 323,351" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
+  <!-- 6. cc-recursive-team → coding-agent-eval (feeds eval) -->
+  <!-- ARC ABOVE row D (y≈300) to avoid crossing research box -->
+  <path d="M 538,327 C 490,295 370,295 323,327" fill="none" stroke="#a371f7" stroke-width="1.5" marker-end="url(#a-purple)"/>
 
-  <!-- 8. dotfiles → ralph-loop (bootstraps) -->
-  <!-- From dotfiles top (310,422) curving up to ralph bottom-left (350,90) -->
-  <path d="M 310,422 C 280,320 300,150 350,90" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
+  <!-- 7. dotfiles → ralph-loop (bootstraps) -->
+  <!-- Route FAR LEFT (x≈100) to avoid eval + polyforge + CABIO: dotfiles left edge → far-left → ralph left edge -->
+  <path d="M 210,446 C 100,400 100,90 330,90" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
 
-  <!-- 9. cc-utils-plugin → ralph-loop (configures) -->
-  <!-- From plugin top (550,422) curving up to ralph bottom-right (500,90) -->
-  <path d="M 550,422 C 580,320 540,150 500,90" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
+  <!-- 8. cc-utils-plugin → ralph-loop (configures) -->
+  <!-- Route FAR RIGHT (x≈760) to avoid recursive + cross-repo + CABIO: plugin right edge → far-right → ralph right edge -->
+  <path d="M 650,446 C 760,400 760,90 530,90" fill="none" stroke="#3fb950" stroke-width="1.5" marker-end="url(#a-green)"/>
 
-  <!-- 10. cross-repo-issue-sync → CABIO-test (syncs to) -->
-  <!-- From sync top (550,232) curving up to CABIO bottom-right (490,185) -->
-  <path d="M 550,232 C 540,210 510,195 490,185" fill="none" stroke="#d29922" stroke-width="1.5" marker-end="url(#a-orange)"/>
+  <!-- 9. cross-repo-issue-sync → CABIO-test (syncs to) -->
+  <!-- Diagonal up through gap between rows C and B: sync top → CABIO bottom-right -->
+  <path d="M 550,232 C 540,210 510,195 530,185" fill="none" stroke="#d29922" stroke-width="1.5" marker-end="url(#a-orange)"/>
 
   <!-- ===== Legend ===== -->
   <line x1="100" y1="488" x2="130" y2="488" stroke="#4493f8" stroke-width="1.5" marker-end="url(#a-blue)"/>


### PR DESCRIPTION
## Summary

- **architecture.svg**: Add 4 new repos (sdlc-lcm-manager, liminal-flux, repo-timeline, github-mirror) across Layers 2-4, bringing total from 21 to 24 repositories
- **interconnections.svg**: Full redesign from Agents-eval-centric to account-level "Agentic Lifecycle Orchestration" with 5 labeled rows, 10 repos, and 11 relationship arrows

## Changes

### architecture.svg
- Layer 2 (Agent Dev Tooling): +sdlc-lcm-manager (7 boxes, w=112)
- Layer 3 (Agent Applications): +liminal-flux (3 wide boxes, w=220)
- Layer 4 (GitHub Actions): +repo-timeline, +github-mirror (7 boxes, w=112)
- Footer updated to 24 repositories

### interconnections.svg
- New narrative: hands-off agentic lifecycle management
- Rows: E2E Coding → Steering → Orchestration → Research → Helpers
- 4 arrow colors: uses/scales (blue), configures/bootstraps (green), creates/syncs (orange), feeds back (purple)
- Feedback loop from evaluation back to ralph-loop and cc-utils-plugin
- viewBox expanded from 860x370 to 860x500

## Test plan

- [ ] Preview architecture.svg renders correctly (6 layers, 24 repos)
- [ ] Preview interconnections.svg renders correctly (5 rows, 10 repos, 11 arrows)
- [ ] Verify light/dark theme auto-switching works
- [ ] Check all GitHub repo URLs are valid

Generated with Claude <noreply@anthropic.com>