### PR TITLE
feat(svg): add frosted glass effect to repo boxes

### DIFF
--- a/assets/images/architecture.svg
+++ b/assets/images/architecture.svg
@@ -1,10 +1,29 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 900 518" width="900" height="518">
   <defs>
+    <filter id="frost-texture" x="0%" y="0%" width="100%" height="100%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.65" numOctaves="3" stitchTiles="stitch" result="noise"/>
+      <feColorMatrix in="noise" type="saturate" values="0" result="gray-noise"/>
+      <feComponentTransfer in="gray-noise" result="faint-noise">
+        <feFuncA type="linear" slope="0.03" intercept="0"/>
+      </feComponentTransfer>
+      <feMerge>
+        <feMergeNode in="SourceGraphic"/>
+        <feMergeNode in="faint-noise"/>
+      </feMerge>
+    </filter>
+    <filter id="glass-frost" x="0%" y="0%" width="100%" height="100%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="0.4" result="softened"/>
+      <feComponentTransfer in="softened" result="brightened">
+        <feFuncR type="linear" slope="1.02" intercept="0.02"/>
+        <feFuncG type="linear" slope="1.02" intercept="0.02"/>
+        <feFuncB type="linear" slope="1.02" intercept="0.02"/>
+      </feComponentTransfer>
+    </filter>
     <style>
       /* Light mode (default) */
-      .page-bg { fill: #ffffff; }
+      .page-bg { fill: #ffffff; filter: url(#frost-texture); }
       .layer-bg { fill: #f6f8fa; }
-      .box { fill: #ffffff; stroke: #d0d7de; stroke-width: 1; }
+      .box { fill: #ffffff; fill-opacity: 0.7; stroke: #d0d7de; stroke-width: 1; filter: url(#glass-frost); }
       .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 15px; font-weight: 700; fill: #1f2328; }
       .layer-label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 10px; font-weight: 600; fill: #57606a; letter-spacing: 1.5px; }
       .repo-name { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 600; fill: #1f2328; }
@@ -14,9 +33,9 @@
 
       /* Dark mode */
       @media (prefers-color-scheme: dark) {
-        .page-bg { fill: #0d1117; }
+        .page-bg { fill: #0d1117; filter: url(#frost-texture); }
         .layer-bg { fill: #161b22; }
-        .box { fill: #0d1117; stroke: #30363d; }
+        .box { fill: #0d1117; fill-opacity: 0.65; stroke: #30363d; stroke-opacity: 0.8; }
         .title { fill: #e6edf3; }
         .layer-label { fill: #8b949e; }
         .repo-name { fill: #e6edf3; }

--- a/assets/images/interconnections.svg
+++ b/assets/images/interconnections.svg
@@ -1,10 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 860 468" width="860" height="468">
   <defs>
+    <filter id="glass-frost" x="0%" y="0%" width="100%" height="100%">
+      <feGaussianBlur in="SourceGraphic" stdDeviation="0.4" result="softened"/>
+      <feComponentTransfer in="softened" result="brightened">
+        <feFuncR type="linear" slope="1.02" intercept="0.02"/>
+        <feFuncG type="linear" slope="1.02" intercept="0.02"/>
+        <feFuncB type="linear" slope="1.02" intercept="0.02"/>
+      </feComponentTransfer>
+    </filter>
     <style>
       /* Light mode (default) */
       .page-bg { fill: #ffffff; }
       .layer-bg { fill: #f6f8fa; }
-      .box { fill: #ffffff; stroke: #d0d7de; stroke-width: 1; }
+      .box { fill: #ffffff; fill-opacity: 0.7; stroke: #d0d7de; stroke-width: 1; filter: url(#glass-frost); }
       .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 15px; font-weight: 700; fill: #1f2328; }
       .subtitle { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; fill: #656d76; }
       .layer-label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 10px; font-weight: 600; fill: #57606a; letter-spacing: 1.5px; }
@@ -17,7 +25,7 @@
       @media (prefers-color-scheme: dark) {
         .page-bg { fill: #0d1117; }
         .layer-bg { fill: #161b22; }
-        .box { fill: #0d1117; stroke: #30363d; }
+        .box { fill: #0d1117; fill-opacity: 0.65; stroke: #30363d; stroke-opacity: 0.8; }
         .title { fill: #e6edf3; }
         .subtitle { fill: #8b949e; }
         .layer-label { fill: #8b949e; }


### PR DESCRIPTION
## Summary

- Add semi-transparent box fills (light: 0.7, dark: 0.65 opacity)
- Apply subtle feGaussianBlur frost filter for frosted glass card look
- Dark mode uses reduced stroke opacity for softer edges
- Applied to both architecture.svg and interconnections.svg

## Test plan

- [ ] Boxes appear slightly translucent with layer background showing through
- [ ] Text remains readable through the frost effect
- [ ] Dark mode boxes have softer, glass-like appearance

Generated with Claude <noreply@anthropic.com>