### PR TITLE
docs: update ecosystem diagrams with 32 repos and self-evolving agents

### DIFF
--- a/.github/workflows/repo-registry.yml
+++ b/.github/workflows/repo-registry.yml
@@ -1,0 +1,23 @@
+---
+name: Update Repo Registry
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly, Monday 6am UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  models: read
+
+jobs:
+  update-registry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: qte77/gha-repo-index@main
+        with:
+          OWNER: qte77
+          OUTPUT_DIR: registry
+          CREATE_PR: "true"

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 
 # qte77
 
-Autonomous agentic lifecycle management — from strategic goals to merged PRs and processed invoices, hands-off. Set a goal, RAPID writes the specs, Ralph codes and ships, Polyforge and Office-forge coordinate across repos and projects, issues sync, progress traces back to the goal.
+Goal-driven development with AI agents — from specs to merged PRs across dev and office repos. RAPID generates specs, Ralph implements via TDD, Polyforge and Office-forge orchestrate across repos, issues sync cross-repo, progress traces back to goals.
 
-> No existing system connects a committed goal artifact through automated spec generation, autonomous implementation across dev and office domains, cross-repo issue aggregation, and progress rollback — end to end.
+> This ecosystem connects a goal artifact through spec generation, autonomous implementation, cross-repo coordination, and traceability — end to end.
 
 ## Repository Landscape
 
@@ -18,11 +18,14 @@ Autonomous agentic lifecycle management — from strategic goals to merged PRs a
 ## Topics
 
 - Agentic Software Development, Autonomous Coding
+- Self-Evolving Agents, Compound Learning
 - Multi-Repo Orchestration, Cross-Repo Issue Sync
 - AI Agent Evaluation, MAS Benchmarking
 - Goal-Driven Lifecycle Management, OKR Traceability
-- GitHub Actions, CI/CD Automation
+- GitHub Actions, CI/CD Automation (REGISTRY → OBSERVE → TRANSFORM → ORCHESTRATE → DISTRIBUTE → IMPLEMENT)
 - Claude Code Plugins, MCP Integrations
+- Agent UI (AG-UI/A2UI), Voice (TTS/STT)
+- Robotics, Bio-Lab Automation
 - Inductive Priors, Automatic Differentiation
 - Data Centric vs Model Centric
 - QML, Barren Plateaus

--- a/assets/images/agent-architecture.svg
+++ b/assets/images/agent-architecture.svg
@@ -1,0 +1,126 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 860 400" width="860" height="400">
+  <defs>
+    <style>
+      .page-bg { fill: #ffffff; }
+      .layer-bg { fill: #f6f8fa; }
+      .box { fill: #ffffff; stroke: #d0d7de; stroke-width: 1; }
+      .box-orch { fill: #ffffff; stroke: #d0d7de; stroke-width: 1.5; }
+      .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 15px; font-weight: 700; fill: #1f2328; }
+      .subtitle { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; fill: #656d76; }
+      .layer-label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 10px; font-weight: 600; fill: #57606a; letter-spacing: 1.5px; }
+      .item-label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 600; fill: #1f2328; }
+      .item-desc { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 9px; fill: #656d76; }
+      .check { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 9px; fill: #1a7f37; }
+      .cross { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 9px; fill: #cf222e; }
+      .bridge { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 9px; fill: #656d76; }
+      .note { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 9px; fill: #8b949e; }
+      .arrow { stroke: #b0b8c1; stroke-width: 1.2; fill: none; marker-end: url(#ah-l); }
+      .arrow-bi { stroke: #b0b8c1; stroke-width: 1.2; fill: none; stroke-dasharray: 4 3; }
+
+      @media (prefers-color-scheme: dark) {
+        .page-bg { fill: #0d1117; }
+        .layer-bg { fill: #161b22; }
+        .box { fill: #0d1117; stroke: #30363d; }
+        .box-orch { fill: #0d1117; stroke: #30363d; }
+        .title { fill: #e6edf3; }
+        .subtitle { fill: #8b949e; }
+        .layer-label { fill: #8b949e; }
+        .item-label { fill: #e6edf3; }
+        .item-desc { fill: #8b949e; }
+        .check { fill: #3fb950; }
+        .cross { fill: #f85149; }
+        .bridge { fill: #8b949e; }
+        .note { fill: #484f58; }
+        .arrow { stroke: #484f58; marker-end: url(#ah-d); }
+        .arrow-bi { stroke: #484f58; }
+      }
+    </style>
+    <marker id="ah-l" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="none" stroke="#b0b8c1" stroke-width="1"/>
+    </marker>
+    <marker id="ah-d" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="none" stroke="#484f58" stroke-width="1"/>
+    </marker>
+  </defs>
+
+  <rect class="page-bg" width="860" height="400" rx="8"/>
+
+  <text class="title" x="430" y="20" text-anchor="middle">Multi-Repo Agent Architecture</text>
+  <text class="subtitle" x="430" y="36" text-anchor="middle">Per-repo context isolation — separate sessions, shared learnings</text>
+
+  <!-- Orchestrator box -->
+  <rect class="layer-bg" x="10" y="48" width="840" height="50" rx="6"/>
+  <text class="layer-label" x="20" y="62">ORCHESTRATOR</text>
+  <text class="item-desc" x="20" y="82">Spawns sessions per repo via prompt templates carrying cross-repo context (targets, issues, skills, priorities)</text>
+
+  <!-- Session boxes -->
+  <rect class="layer-bg" x="10" y="104" width="840" height="140" rx="6"/>
+  <text class="layer-label" x="20" y="118">PER-REPO SESSIONS (isolated context)</text>
+
+  <!-- Session A -->
+  <rect class="box" x="30" y="126" width="250" height="108" rx="5"/>
+  <text class="item-label" x="155" y="144" text-anchor="middle">repo-A session</text>
+  <text class="check" x="50" y="162">✓ CLAUDE.md loaded</text>
+  <text class="check" x="50" y="176">✓ .claude/rules/ active</text>
+  <text class="check" x="50" y="190">✓ hooks fire (SessionStart)</text>
+  <text class="check" x="50" y="204">✓ plugins + skills available</text>
+  <text class="cross" x="50" y="222">✗ other repos' context not loaded</text>
+
+  <!-- Session B -->
+  <rect class="box" x="305" y="126" width="250" height="108" rx="5"/>
+  <text class="item-label" x="430" y="144" text-anchor="middle">repo-B session</text>
+  <text class="check" x="325" y="162">✓ CLAUDE.md loaded</text>
+  <text class="check" x="325" y="176">✓ .claude/rules/ active</text>
+  <text class="check" x="325" y="190">✓ hooks fire (SessionStart)</text>
+  <text class="check" x="325" y="204">✓ plugins + skills available</text>
+  <text class="cross" x="325" y="222">✗ other repos' context not loaded</text>
+
+  <!-- Session C -->
+  <rect class="box" x="580" y="126" width="250" height="108" rx="5"/>
+  <text class="item-label" x="705" y="144" text-anchor="middle">repo-C session</text>
+  <text class="check" x="600" y="162">✓ CLAUDE.md loaded</text>
+  <text class="check" x="600" y="176">✓ .claude/rules/ active</text>
+  <text class="check" x="600" y="190">✓ hooks fire (SessionStart)</text>
+  <text class="check" x="600" y="204">✓ plugins + skills available</text>
+  <text class="cross" x="600" y="222">✗ other repos' context not loaded</text>
+
+  <!-- Bridges section -->
+  <rect class="layer-bg" x="10" y="250" width="840" height="122" rx="6"/>
+  <text class="layer-label" x="20" y="264">BRIDGES ACROSS SESSIONS</text>
+
+  <rect class="box" x="30" y="274" width="150" height="44" rx="5"/>
+  <text class="item-label" x="105" y="292" text-anchor="middle">Prompt templates</text>
+  <text class="item-desc" x="105" y="306" text-anchor="middle">orchestrator → agent</text>
+
+  <rect class="box" x="196" y="274" width="150" height="44" rx="5"/>
+  <text class="item-label" x="271" y="292" text-anchor="middle">Git state</text>
+  <text class="item-desc" x="271" y="306" text-anchor="middle">agent → orchestrator</text>
+
+  <rect class="box" x="362" y="274" width="150" height="44" rx="5"/>
+  <text class="item-label" x="437" y="292" text-anchor="middle">Compound learnings</text>
+  <text class="item-desc" x="437" y="306" text-anchor="middle">agent ↔ agent</text>
+
+  <rect class="box" x="528" y="274" width="150" height="44" rx="5"/>
+  <text class="item-label" x="603" y="292" text-anchor="middle">CC plans</text>
+  <text class="item-desc" x="603" y="306" text-anchor="middle">session → session</text>
+
+  <rect class="box" x="694" y="274" width="150" height="44" rx="5"/>
+  <text class="item-label" x="769" y="292" text-anchor="middle">CC memory</text>
+  <text class="item-desc" x="769" y="306" text-anchor="middle">session → session</text>
+
+  <!-- Arrows from orchestrator to sessions -->
+  <line class="arrow" x1="155" y1="98" x2="155" y2="126"/>
+  <line class="arrow" x1="430" y1="98" x2="430" y2="126"/>
+  <line class="arrow" x1="705" y1="98" x2="705" y2="126"/>
+
+  <!-- Bidirectional arrows sessions to bridges -->
+  <line class="arrow-bi" x1="155" y1="234" x2="155" y2="274"/>
+  <line class="arrow-bi" x1="430" y1="234" x2="430" y2="274"/>
+  <line class="arrow-bi" x1="705" y1="234" x2="705" y2="274"/>
+
+  <!-- Footer -->
+  <text class="note" x="20" y="356">Constraint: each session loads only its own repo's CLAUDE.md, rules, hooks, and plugins</text>
+  <text class="note" x="840" y="356" text-anchor="end">Bridges carry cross-repo context without violating isolation</text>
+
+  <text class="note" x="20" y="384">Design: prompt templates inject orchestrator context • results aggregate via git • compound learnings are the shared state store</text>
+</svg>

--- a/assets/images/architecture.svg
+++ b/assets/images/architecture.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 900 518" width="900" height="518">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 900 580" width="900" height="580">
   <defs>
     <style>
       /* Light mode (default) */
@@ -28,7 +28,7 @@
   </defs>
 
   <!-- Page background -->
-  <rect class="page-bg" width="900" height="518" rx="8"/>
+  <rect class="page-bg" width="900" height="580" rx="8"/>
 
   <!-- Title -->
   <text class="title" x="450" y="24" text-anchor="middle">qte77 — Project Ecosystem</text>
@@ -58,36 +58,50 @@
     <text class="repo-desc" x="700" y="90" text-anchor="middle">scientific report gen</text>
   </a>
 
-  <!-- ===== Layer 2: Agentic Development Engine (4 boxes, w=190, gap=20, start=40) ===== -->
+  <!-- ===== Layer 2: Agentic Development Engine (6 boxes, w=130, gap=14, start=25) ===== -->
   <rect class="layer-bg" x="10" y="118" width="880" height="74" rx="6"/>
   <text class="layer-label" x="20" y="132">AGENTIC DEVELOPMENT ENGINE</text>
 
-  <a xlink:href="https://github.com/qte77/polyforge">
-    <title>polyforge — Polyrepo dev forge for parallel AI agent workflows across multiple repositories</title>
-    <rect class="box" x="40" y="136" width="190" height="48" rx="5"/>
-    <text class="repo-name" x="135" y="155" text-anchor="middle">polyforge</text>
-    <text class="repo-desc" x="135" y="170" text-anchor="middle">multi-repo orchestration</text>
+  <a xlink:href="https://github.com/qte77/polyforge-orchestrator">
+    <title>polyforge-orchestrator — Multi-repo dev forge for parallel AI agent workflows</title>
+    <rect class="box" x="25" y="136" width="130" height="48" rx="5"/>
+    <text class="repo-name" x="90" y="155" text-anchor="middle">polyforge</text>
+    <text class="repo-desc" x="90" y="170" text-anchor="middle">multi-repo orchestration</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/office-forge">
-    <title>office-forge — Parallel AI agent sessions across office projects (invoices, contracts, reports)</title>
-    <rect class="box" x="250" y="136" width="190" height="48" rx="5"/>
-    <text class="repo-name" x="345" y="155" text-anchor="middle">office-forge</text>
-    <text class="repo-desc" x="345" y="170" text-anchor="middle">office project orchestration</text>
+    <title>office-forge — Parallel AI agent sessions across office projects</title>
+    <rect class="box" x="169" y="136" width="130" height="48" rx="5"/>
+    <text class="repo-name" x="234" y="155" text-anchor="middle">office-forge</text>
+    <text class="repo-desc" x="234" y="170" text-anchor="middle">office orchestration</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template">
-    <title>ralph-loop template — Autonomous development loop with Claude Code, TDD, and kanban</title>
-    <rect class="box" x="460" y="136" width="190" height="48" rx="5"/>
-    <text class="repo-name" x="555" y="155" text-anchor="middle">ralph-loop template</text>
-    <text class="repo-desc" x="555" y="170" text-anchor="middle">autonomous dev loop</text>
+    <title>ralph-loop template — Autonomous development loop with TDD and kanban</title>
+    <rect class="box" x="313" y="136" width="130" height="48" rx="5"/>
+    <text class="repo-name" x="378" y="155" text-anchor="middle">ralph-loop</text>
+    <text class="repo-desc" x="378" y="170" text-anchor="middle">autonomous dev loop</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/ai-agents-research">
     <title>ai-agents-research — Field research and feature analysis for AI coding agents</title>
-    <rect class="box" x="670" y="136" width="190" height="48" rx="5"/>
-    <text class="repo-name" x="765" y="155" text-anchor="middle">ai-agents-research</text>
-    <text class="repo-desc" x="765" y="170" text-anchor="middle">AI agent field research</text>
+    <rect class="box" x="457" y="136" width="130" height="48" rx="5"/>
+    <text class="repo-name" x="522" y="155" text-anchor="middle">ai-agents-research</text>
+    <text class="repo-desc" x="522" y="170" text-anchor="middle">AI agent field research</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/learnings-ralphy">
+    <title>learnings-ralphy — Self-evolving ralph offspring distilling operational patterns</title>
+    <rect class="box" x="601" y="136" width="130" height="48" rx="5"/>
+    <text class="repo-name" x="666" y="155" text-anchor="middle">learnings-ralphy</text>
+    <text class="repo-desc" x="666" y="170" text-anchor="middle">self-evolving patterns</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/research-ralphy">
+    <title>research-ralphy — Self-evolving ralph offspring implementing research discoveries</title>
+    <rect class="box" x="745" y="136" width="130" height="48" rx="5"/>
+    <text class="repo-name" x="810" y="155" text-anchor="middle">research-ralphy</text>
+    <text class="repo-desc" x="810" y="170" text-anchor="middle">self-evolving research</text>
   </a>
 
   <!-- ===== Layer 3: AI Agent Evaluation (6 boxes, w=134, gap=12, start=18) ===== -->
@@ -136,96 +150,142 @@
     <text class="repo-desc" x="815" y="250" text-anchor="middle">3-tier MAS evaluation</text>
   </a>
 
-  <!-- ===== Layer 4: GitHub Actions (7 boxes, w=112, gap=10, start=28) ===== -->
+  <!-- ===== Layer 4: GitHub Actions (9 boxes, w=88, gap=7, start=26) ===== -->
   <rect class="layer-bg" x="10" y="278" width="880" height="74" rx="6"/>
   <text class="layer-label" x="20" y="292">GITHUB ACTIONS</text>
 
+  <a xlink:href="https://github.com/qte77/gha-repo-index">
+    <title>gha-repo-index — Registry SOT: indexes all repos into registry/index.json</title>
+    <rect class="box" x="26" y="296" width="88" height="48" rx="5"/>
+    <text class="repo-name" x="70" y="315" text-anchor="middle">repo-index</text>
+    <text class="repo-desc" x="70" y="330" text-anchor="middle">registry SOT</text>
+  </a>
+
   <a xlink:href="https://github.com/qte77/gha-ai-changelog">
     <title>gha-ai-changelog — AI-powered changelog generation from PRs</title>
-    <rect class="box" x="28" y="296" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="84" y="315" text-anchor="middle">ai-changelog</text>
-    <text class="repo-desc" x="84" y="330" text-anchor="middle">AI-powered changelogs</text>
+    <rect class="box" x="121" y="296" width="88" height="48" rx="5"/>
+    <text class="repo-name" x="165" y="315" text-anchor="middle">ai-changelog</text>
+    <text class="repo-desc" x="165" y="330" text-anchor="middle">AI changelogs</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-contribution-ascii">
     <title>gha-contribution-ascii — Write ASCII art onto GitHub contribution graph</title>
-    <rect class="box" x="150" y="296" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="206" y="315" text-anchor="middle">contribution-ascii</text>
-    <text class="repo-desc" x="206" y="330" text-anchor="middle">contribution graph art</text>
+    <rect class="box" x="216" y="296" width="88" height="48" rx="5"/>
+    <text class="repo-name" x="260" y="315" text-anchor="middle">contrib-ascii</text>
+    <text class="repo-desc" x="260" y="330" text-anchor="middle">graph art</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-dirtree-to-readme">
     <title>gha-dirtree-to-readme — Auto-insert directory tree into README</title>
-    <rect class="box" x="272" y="296" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="328" y="315" text-anchor="middle">dirtree-to-readme</text>
-    <text class="repo-desc" x="328" y="330" text-anchor="middle">dir tree to README</text>
+    <rect class="box" x="311" y="296" width="88" height="48" rx="5"/>
+    <text class="repo-name" x="355" y="315" text-anchor="middle">dirtree-readme</text>
+    <text class="repo-desc" x="355" y="330" text-anchor="middle">dir tree sync</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-arxiv-stats-action">
     <title>gha-arxiv-stats-action — Logs daily stats of papers submitted to arxiv.org</title>
-    <rect class="box" x="394" y="296" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="450" y="315" text-anchor="middle">arxiv-stats-action</text>
-    <text class="repo-desc" x="450" y="330" text-anchor="middle">arXiv daily paper stats</text>
+    <rect class="box" x="406" y="296" width="88" height="48" rx="5"/>
+    <text class="repo-name" x="450" y="315" text-anchor="middle">arxiv-stats</text>
+    <text class="repo-desc" x="450" y="330" text-anchor="middle">arXiv papers</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/gha-biorxiv-stats-action">
+    <title>gha-biorxiv-stats-action — Logs daily stats of papers submitted to biorxiv.org</title>
+    <rect class="box" x="501" y="296" width="88" height="48" rx="5"/>
+    <text class="repo-name" x="545" y="315" text-anchor="middle">biorxiv-stats</text>
+    <text class="repo-desc" x="545" y="330" text-anchor="middle">bioRxiv papers</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-cross-repo-issue-sync">
     <title>gha-cross-repo-issue-sync — Synchronize issues across repositories</title>
-    <rect class="box" x="516" y="296" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="572" y="315" text-anchor="middle">issue-sync</text>
-    <text class="repo-desc" x="572" y="330" text-anchor="middle">cross-repo issues</text>
+    <rect class="box" x="596" y="296" width="88" height="48" rx="5"/>
+    <text class="repo-name" x="640" y="315" text-anchor="middle">issue-sync</text>
+    <text class="repo-desc" x="640" y="330" text-anchor="middle">cross-repo issues</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-arbitrary-repo-timeline">
     <title>gha-arbitrary-repo-timeline — Generate timeline visualizations for any repo</title>
-    <rect class="box" x="638" y="296" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="694" y="315" text-anchor="middle">repo-timeline</text>
-    <text class="repo-desc" x="694" y="330" text-anchor="middle">repo timeline viz</text>
+    <rect class="box" x="691" y="296" width="88" height="48" rx="5"/>
+    <text class="repo-name" x="735" y="315" text-anchor="middle">repo-timeline</text>
+    <text class="repo-desc" x="735" y="330" text-anchor="middle">timeline viz</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-github-mirror-action">
-    <title>gha-github-mirror-action — Mirror repositories across GitHub accounts</title>
-    <rect class="box" x="760" y="296" width="112" height="48" rx="5"/>
-    <text class="repo-name" x="816" y="315" text-anchor="middle">github-mirror</text>
-    <text class="repo-desc" x="816" y="330" text-anchor="middle">repo mirroring</text>
+    <title>gha-github-mirror-action — Mirror repositories across platforms</title>
+    <rect class="box" x="786" y="296" width="88" height="48" rx="5"/>
+    <text class="repo-name" x="830" y="315" text-anchor="middle">github-mirror</text>
+    <text class="repo-desc" x="830" y="330" text-anchor="middle">repo mirroring</text>
   </a>
 
-  <!-- ===== Layer 5: Infrastructure (2 boxes, w=220, gap=40, start=210) ===== -->
+  <!-- ===== Layer 5: Infrastructure & Plugins (4 boxes, w=190, gap=20, start=40) ===== -->
   <rect class="layer-bg" x="10" y="358" width="880" height="62" rx="6"/>
-  <text class="layer-label" x="20" y="372">INFRASTRUCTURE</text>
+  <text class="layer-label" x="20" y="372">INFRASTRUCTURE &amp; PLUGINS</text>
 
   <a xlink:href="https://github.com/qte77/dotfiles">
     <title>dotfiles — Personal dev environment config for Codespaces and devcontainers</title>
-    <rect class="box" x="210" y="374" width="220" height="38" rx="5"/>
-    <text class="repo-name" x="320" y="389" text-anchor="middle">dotfiles</text>
-    <text class="repo-desc" x="320" y="403" text-anchor="middle">dev environment config</text>
+    <rect class="box" x="40" y="374" width="190" height="38" rx="5"/>
+    <text class="repo-name" x="135" y="389" text-anchor="middle">dotfiles</text>
+    <text class="repo-desc" x="135" y="403" text-anchor="middle">dev environment config</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/claude-code-utils-plugin">
-    <title>claude-code-utils-plugin — CC plugin marketplace with skills, rules, and scripts</title>
-    <rect class="box" x="470" y="374" width="220" height="38" rx="5"/>
-    <text class="repo-name" x="580" y="389" text-anchor="middle">cc-utils-plugin</text>
-    <text class="repo-desc" x="580" y="403" text-anchor="middle">plugins &amp; skills</text>
+    <title>claude-code-utils-plugin — CC plugin marketplace with 20 plugins and 37 skills</title>
+    <rect class="box" x="250" y="374" width="190" height="38" rx="5"/>
+    <text class="repo-name" x="345" y="389" text-anchor="middle">cc-utils-plugin</text>
+    <text class="repo-desc" x="345" y="403" text-anchor="middle">20 plugins, 37 skills</text>
   </a>
-
-  <!-- ===== Layer 6: Experimental (2 boxes, w=220, gap=40, start=210) ===== -->
-  <rect class="layer-bg" x="10" y="426" width="880" height="62" rx="6"/>
-  <text class="layer-label" x="20" y="440">EXPERIMENTAL</text>
 
   <a xlink:href="https://github.com/qte77/cc-recursive-team-mode">
-    <title>cc-recursive-team-mode — Claude Code subprocess wrapper, recursive spawning, and artifact parser</title>
-    <rect class="box" x="210" y="442" width="220" height="38" rx="5"/>
-    <text class="repo-name" x="320" y="457" text-anchor="middle">cc-recursive-team</text>
-    <text class="repo-desc" x="320" y="471" text-anchor="middle">recursive agent spawning</text>
+    <title>cc-recursive-team-mode — Claude Code subprocess wrapper and recursive spawning</title>
+    <rect class="box" x="460" y="374" width="190" height="38" rx="5"/>
+    <text class="repo-name" x="555" y="389" text-anchor="middle">cc-recursive-team</text>
+    <text class="repo-desc" x="555" y="403" text-anchor="middle">recursive agent spawning</text>
   </a>
 
+  <a xlink:href="https://github.com/qte77/eyerest-vscode-theme">
+    <title>eyerest-vscode-theme — Eye-friendly VS Code themes with zero blue light</title>
+    <rect class="box" x="670" y="374" width="190" height="38" rx="5"/>
+    <text class="repo-name" x="765" y="389" text-anchor="middle">eyerest-vscode-theme</text>
+    <text class="repo-desc" x="765" y="403" text-anchor="middle">eye-friendly VS Code</text>
+  </a>
+
+  <!-- ===== Layer 6: Agent UI, Voice & Robotics (3 boxes, w=220, gap=30, start=90) ===== -->
+  <rect class="layer-bg" x="10" y="426" width="880" height="62" rx="6"/>
+  <text class="layer-label" x="20" y="440">AGENT UI, VOICE &amp; ROBOTICS</text>
+
+  <a xlink:href="https://github.com/qte77/agenthud-agui-a2ui">
+    <title>agenthud-agui-a2ui — AG-UI event replay and A2UI component rendering</title>
+    <rect class="box" x="90" y="442" width="220" height="38" rx="5"/>
+    <text class="repo-name" x="200" y="457" text-anchor="middle">agenthud-agui-a2ui</text>
+    <text class="repo-desc" x="200" y="471" text-anchor="middle">AG-UI + A2UI rendering</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/cc-voice-plugin-prototype">
+    <title>cc-voice-plugin-prototype — End-to-end voice for Claude Code: TTS + STT</title>
+    <rect class="box" x="340" y="442" width="220" height="38" rx="5"/>
+    <text class="repo-name" x="450" y="457" text-anchor="middle">cc-voice-plugin</text>
+    <text class="repo-desc" x="450" y="471" text-anchor="middle">TTS + STT for Claude Code</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/so101-biolab-automation">
+    <title>so101-biolab-automation — Dual SO-101 robotic arm bio-lab automation</title>
+    <rect class="box" x="590" y="442" width="220" height="38" rx="5"/>
+    <text class="repo-name" x="700" y="457" text-anchor="middle">so101-biolab</text>
+    <text class="repo-desc" x="700" y="471" text-anchor="middle">robotic arm bio-lab</text>
+  </a>
+
+  <!-- ===== Layer 7: Experimental (1 box, centered) ===== -->
+  <rect class="layer-bg" x="10" y="494" width="880" height="62" rx="6"/>
+  <text class="layer-label" x="20" y="508">EXPERIMENTAL</text>
+
   <a xlink:href="https://github.com/qte77/liminal-flux-gh-acc">
-    <title>liminal-flux — Self-evolving agent-operated GitHub account (Lim Sid)</title>
-    <rect class="box" x="470" y="442" width="220" height="38" rx="5"/>
-    <text class="repo-name" x="580" y="457" text-anchor="middle">liminal-flux</text>
-    <text class="repo-desc" x="580" y="471" text-anchor="middle">agent-operated GH account</text>
+    <title>liminal-flux — Self-evolving agent-operated GitHub account (North Star)</title>
+    <rect class="box" x="330" y="510" width="240" height="38" rx="5"/>
+    <text class="repo-name" x="450" y="525" text-anchor="middle">liminal-flux</text>
+    <text class="repo-desc" x="450" y="539" text-anchor="middle">agent-operated GH account</text>
   </a>
 
   <!-- Footer -->
-  <text class="note" x="20" y="506">* pat-tax/ org</text>
-  <text class="note" x="880" y="506" text-anchor="end">22 repositories</text>
+  <text class="note" x="20" y="572">* pat-tax/ org</text>
+  <text class="note" x="880" y="572" text-anchor="end">32 repositories</text>
 </svg>

--- a/assets/images/decision-flow.svg
+++ b/assets/images/decision-flow.svg
@@ -1,0 +1,109 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 860 440" width="860" height="440">
+  <defs>
+    <style>
+      .page-bg { fill: #ffffff; }
+      .layer-bg { fill: #f6f8fa; }
+      .box { fill: #ffffff; stroke: #d0d7de; stroke-width: 1; }
+      .box-decision { fill: #ffffff; stroke: #d0d7de; stroke-width: 1.5; }
+      .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 15px; font-weight: 700; fill: #1f2328; }
+      .subtitle { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; fill: #656d76; }
+      .item-label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; font-weight: 600; fill: #1f2328; }
+      .item-desc { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 9px; fill: #656d76; }
+      .cond { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 10px; font-weight: 600; fill: #57606a; }
+      .note { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 9px; fill: #8b949e; }
+      .arrow { stroke: #b0b8c1; stroke-width: 1.2; fill: none; marker-end: url(#ah-l); }
+
+      @media (prefers-color-scheme: dark) {
+        .page-bg { fill: #0d1117; }
+        .layer-bg { fill: #161b22; }
+        .box { fill: #0d1117; stroke: #30363d; }
+        .box-decision { fill: #0d1117; stroke: #30363d; }
+        .title { fill: #e6edf3; }
+        .subtitle { fill: #8b949e; }
+        .item-label { fill: #e6edf3; }
+        .item-desc { fill: #8b949e; }
+        .cond { fill: #8b949e; }
+        .note { fill: #484f58; }
+        .arrow { stroke: #484f58; marker-end: url(#ah-d); }
+      }
+    </style>
+    <marker id="ah-l" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="none" stroke="#b0b8c1" stroke-width="1"/>
+    </marker>
+    <marker id="ah-d" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="none" stroke="#484f58" stroke-width="1"/>
+    </marker>
+  </defs>
+
+  <rect class="page-bg" width="860" height="440" rx="8"/>
+
+  <text class="title" x="430" y="20" text-anchor="middle">Workflow Decision Flow</text>
+  <text class="subtitle" x="430" y="36" text-anchor="middle">Route tasks to the right execution pattern</text>
+
+  <!-- Task arrives -->
+  <rect class="box-decision" x="355" y="50" width="150" height="36" rx="5"/>
+  <text class="item-label" x="430" y="73" text-anchor="middle">Task arrives</text>
+
+  <!-- Row 1: Multi-repo and Research -->
+  <line class="arrow" x1="430" y1="86" x2="430" y2="110"/>
+
+  <!-- Decision: Multi-repo? -->
+  <text class="cond" x="200" y="120">Spans multiple repos?</text>
+  <line class="arrow" x1="355" y1="115" x2="200" y2="115"/>
+  <rect class="box" x="30" y="130" width="170" height="44" rx="5"/>
+  <text class="item-label" x="115" y="148" text-anchor="middle">Fork workflow</text>
+  <text class="item-desc" x="115" y="162" text-anchor="middle">triage → implement → PR</text>
+  <line class="arrow" x1="115" y1="115" x2="115" y2="130"/>
+
+  <!-- Decision: Research? -->
+  <text class="cond" x="560" y="120">Research / multi-approach?</text>
+  <line class="arrow" x1="505" y1="115" x2="660" y2="115"/>
+  <rect class="box" x="660" y="130" width="170" height="44" rx="5"/>
+  <text class="item-label" x="745" y="148" text-anchor="middle">CC Plan Mode</text>
+  <text class="item-desc" x="745" y="162" text-anchor="middle">explore → plan → handoff</text>
+  <line class="arrow" x1="745" y1="115" x2="745" y2="130"/>
+
+  <!-- Row 2: Major feature -->
+  <line class="arrow" x1="430" y1="110" x2="430" y2="200"/>
+  <text class="cond" x="200" y="210">Major feature (5+ files)?</text>
+  <line class="arrow" x1="355" y1="205" x2="200" y2="205"/>
+
+  <rect class="box" x="30" y="220" width="170" height="44" rx="5"/>
+  <text class="item-label" x="115" y="238" text-anchor="middle">Ralph loop</text>
+  <text class="item-desc" x="115" y="252" text-anchor="middle">PRD → TDD → worktree</text>
+  <line class="arrow" x1="115" y1="205" x2="115" y2="220"/>
+
+  <!-- Ralph sub-decisions -->
+  <rect class="box" x="30" y="274" width="170" height="36" rx="5"/>
+  <text class="item-desc" x="115" y="290" text-anchor="middle">independent → teams (N_WT&gt;1)</text>
+  <text class="item-desc" x="115" y="302" text-anchor="middle">sequential → single (N_WT=1)</text>
+  <line class="arrow" x1="115" y1="264" x2="115" y2="274"/>
+
+  <!-- Decision: Parallel subtasks? -->
+  <text class="cond" x="560" y="210">Parallel subtasks?</text>
+  <line class="arrow" x1="505" y1="205" x2="660" y2="205"/>
+  <rect class="box" x="660" y="220" width="170" height="44" rx="5"/>
+  <text class="item-label" x="745" y="238" text-anchor="middle">CC Agent Teams</text>
+  <text class="item-desc" x="745" y="252" text-anchor="middle">lead/teammate hierarchy</text>
+  <line class="arrow" x1="745" y1="205" x2="745" y2="220"/>
+
+  <!-- Row 3: Small fix and Docs -->
+  <line class="arrow" x1="430" y1="200" x2="430" y2="330"/>
+  <text class="cond" x="200" y="340">Small fix (1-3 files)?</text>
+  <line class="arrow" x1="355" y1="335" x2="200" y2="335"/>
+
+  <rect class="box" x="30" y="350" width="170" height="44" rx="5"/>
+  <text class="item-label" x="115" y="368" text-anchor="middle">CC interactive</text>
+  <text class="item-desc" x="115" y="382" text-anchor="middle">skills, no orchestration</text>
+  <line class="arrow" x1="115" y1="335" x2="115" y2="350"/>
+
+  <text class="cond" x="560" y="340">Documentation?</text>
+  <line class="arrow" x1="505" y1="335" x2="660" y2="335"/>
+  <rect class="box" x="660" y="350" width="170" height="44" rx="5"/>
+  <text class="item-label" x="745" y="368" text-anchor="middle">docs-governance</text>
+  <text class="item-desc" x="745" y="382" text-anchor="middle">hierarchy + maintenance</text>
+  <line class="arrow" x1="745" y1="335" x2="745" y2="350"/>
+
+  <!-- Footer -->
+  <text class="note" x="430" y="428" text-anchor="middle">Route by scope and complexity — smallest viable pattern wins</text>
+</svg>

--- a/assets/images/toolchain-layers.svg
+++ b/assets/images/toolchain-layers.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 860 548" width="860" height="548">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 860 628" width="860" height="628">
   <defs>
     <style>
       /* Light mode (default) */
@@ -12,6 +12,7 @@
       .repo-desc { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 9px; fill: #656d76; }
       .note { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 9px; fill: #8b949e; }
       .arrow { stroke: #b0b8c1; stroke-width: 1.2; fill: none; marker-end: url(#arrowhead-light); }
+      .arrow-feedback { stroke: #b0b8c1; stroke-width: 1.2; fill: none; stroke-dasharray: 4 3; marker-end: url(#arrowhead-light); }
 
       a:hover .box { stroke: #1f2328; stroke-width: 1.5; }
 
@@ -27,6 +28,7 @@
         .repo-desc { fill: #8b949e; }
         .note { fill: #484f58; }
         .arrow { stroke: #484f58; marker-end: url(#arrowhead-dark); }
+        .arrow-feedback { stroke: #484f58; marker-end: url(#arrowhead-dark); }
 
         a:hover .box { stroke: #e6edf3; }
       }
@@ -40,13 +42,13 @@
   </defs>
 
   <!-- Page background -->
-  <rect class="page-bg" width="860" height="548" rx="8"/>
+  <rect class="page-bg" width="860" height="628" rx="8"/>
 
   <!-- Title + subtitle -->
   <text class="title" x="430" y="20" text-anchor="middle">Goal-to-Delivery Toolchain</text>
   <text class="subtitle" x="430" y="36" text-anchor="middle">From strategic intent to merged PRs and processed documents — traced end to end</text>
 
-  <!-- ===== Layer 1: Goals & Northstar (1 box, centered) ===== -->
+  <!-- ===== Layer 1: Goals & Northstar ===== -->
   <rect class="layer-bg" x="10" y="48" width="840" height="74" rx="6"/>
   <text class="layer-label" x="20" y="62">GOALS &amp; NORTHSTAR</text>
 
@@ -54,7 +56,7 @@
   <text class="repo-name" x="430" y="85" text-anchor="middle">goals.json</text>
   <text class="repo-desc" x="430" y="100" text-anchor="middle">SOT for strategic intent</text>
 
-  <!-- ===== Layer 2: Spec Generation (1 box, centered) ===== -->
+  <!-- ===== Layer 2: Spec Generation ===== -->
   <rect class="layer-bg" x="10" y="128" width="840" height="74" rx="6"/>
   <text class="layer-label" x="20" y="142">SPEC GENERATION</text>
 
@@ -65,13 +67,12 @@
     <text class="repo-desc" x="430" y="180" text-anchor="middle">BRD → PRD → FRD</text>
   </a>
 
-  <!-- ===== Layer 3: Orchestration (3 boxes) ===== -->
-  <!-- w=200, gap=20. Total=640. start=(840-640)/2+10=110. Boxes: 110, 330, 550. Centers: 210, 430, 650 -->
+  <!-- ===== Layer 3: Orchestration & Tracking (3 boxes) ===== -->
   <rect class="layer-bg" x="10" y="208" width="840" height="74" rx="6"/>
   <text class="layer-label" x="20" y="222">ORCHESTRATION &amp; TRACKING</text>
 
-  <a xlink:href="https://github.com/qte77/polyforge">
-    <title>polyforge — Parallel AI agent sessions across dev repos</title>
+  <a xlink:href="https://github.com/qte77/polyforge-orchestrator">
+    <title>polyforge-orchestrator — Parallel AI agent sessions across dev repos</title>
     <rect class="box" x="110" y="226" width="200" height="48" rx="5"/>
     <text class="repo-name" x="210" y="245" text-anchor="middle">polyforge</text>
     <text class="repo-desc" x="210" y="260" text-anchor="middle">dev repo orchestration</text>
@@ -91,7 +92,7 @@
     <text class="repo-desc" x="650" y="260" text-anchor="middle">issue tracking + GHA sync</text>
   </a>
 
-  <!-- ===== Layer 4: Autonomous Execution (1 box, centered) ===== -->
+  <!-- ===== Layer 4: Autonomous Execution ===== -->
   <rect class="layer-bg" x="10" y="288" width="840" height="74" rx="6"/>
   <text class="layer-label" x="20" y="302">AUTONOMOUS EXECUTION</text>
 
@@ -102,34 +103,51 @@
     <text class="repo-desc" x="430" y="340" text-anchor="middle">goal → story → code → PR</text>
   </a>
 
-  <!-- ===== Layer 5: Insight Capture (2 boxes) ===== -->
-  <!-- w=200, gap=40. Total=440. start=(840-440)/2+10=210. Boxes: 210, 450. Centers: 310, 550 -->
+  <!-- ===== Layer 5: Self-Evolving Agents (NEW — 2 boxes) ===== -->
   <rect class="layer-bg" x="10" y="368" width="840" height="74" rx="6"/>
-  <text class="layer-label" x="20" y="382">INSIGHT CAPTURE</text>
+  <text class="layer-label" x="20" y="382">SELF-EVOLVING AGENTS</text>
+
+  <a xlink:href="https://github.com/qte77/learnings-ralphy">
+    <title>learnings-ralphy — Self-evolving ralph offspring distilling operational patterns</title>
+    <rect class="box" x="210" y="386" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="310" y="405" text-anchor="middle">learnings-ralphy</text>
+    <text class="repo-desc" x="310" y="420" text-anchor="middle">patterns → improvements</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/research-ralphy">
+    <title>research-ralphy — Self-evolving ralph offspring implementing research discoveries</title>
+    <rect class="box" x="450" y="386" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="550" y="405" text-anchor="middle">research-ralphy</text>
+    <text class="repo-desc" x="550" y="420" text-anchor="middle">discoveries → implementations</text>
+  </a>
+
+  <!-- ===== Layer 6: Insight Capture (2 boxes) ===== -->
+  <rect class="layer-bg" x="10" y="448" width="840" height="74" rx="6"/>
+  <text class="layer-label" x="20" y="462">INSIGHT CAPTURE</text>
 
   <a xlink:href="https://github.com/qte77/ai-agents-research">
     <title>ai-agents-research — Learnings, external input, field research</title>
-    <rect class="box" x="210" y="386" width="200" height="48" rx="5"/>
-    <text class="repo-name" x="310" y="405" text-anchor="middle">ai-agents-research</text>
-    <text class="repo-desc" x="310" y="420" text-anchor="middle">learnings + external input</text>
+    <rect class="box" x="210" y="466" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="310" y="485" text-anchor="middle">ai-agents-research</text>
+    <text class="repo-desc" x="310" y="500" text-anchor="middle">learnings + external input</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/claude-code-utils-plugin">
     <title>cc-utils-plugin — Modular skills, rules, and workspace plugins</title>
-    <rect class="box" x="450" y="386" width="200" height="48" rx="5"/>
-    <text class="repo-name" x="550" y="405" text-anchor="middle">cc-utils-plugin</text>
-    <text class="repo-desc" x="550" y="420" text-anchor="middle">skills + rules + workspaces</text>
+    <rect class="box" x="450" y="466" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="550" y="485" text-anchor="middle">cc-utils-plugin</text>
+    <text class="repo-desc" x="550" y="500" text-anchor="middle">skills + rules + workspaces</text>
   </a>
 
-  <!-- ===== Layer 6: Infrastructure (1 box, centered) ===== -->
-  <rect class="layer-bg" x="10" y="448" width="840" height="74" rx="6"/>
-  <text class="layer-label" x="20" y="462">INFRASTRUCTURE</text>
+  <!-- ===== Layer 7: Infrastructure ===== -->
+  <rect class="layer-bg" x="10" y="528" width="840" height="74" rx="6"/>
+  <text class="layer-label" x="20" y="542">INFRASTRUCTURE</text>
 
   <a xlink:href="https://github.com/qte77/dotfiles">
     <title>dotfiles — Dev environment config for Codespaces and devcontainers</title>
-    <rect class="box" x="330" y="466" width="200" height="48" rx="5"/>
-    <text class="repo-name" x="430" y="485" text-anchor="middle">dotfiles</text>
-    <text class="repo-desc" x="430" y="500" text-anchor="middle">dev environment config</text>
+    <rect class="box" x="330" y="546" width="200" height="48" rx="5"/>
+    <text class="repo-name" x="430" y="565" text-anchor="middle">dotfiles</text>
+    <text class="repo-desc" x="430" y="580" text-anchor="middle">dev environment config</text>
   </a>
 
   <!-- ===== Arrows: downward flow ===== -->
@@ -138,7 +156,12 @@
   <line class="arrow" x1="430" y1="274" x2="430" y2="306"/>
   <line class="arrow" x1="430" y1="354" x2="430" y2="386"/>
   <line class="arrow" x1="430" y1="434" x2="430" y2="466"/>
+  <line class="arrow" x1="430" y1="514" x2="430" y2="546"/>
+
+  <!-- Feedback arrow: insights flow back up (dashed, right side) -->
+  <path class="arrow-feedback" d="M 770,490 L 770,90 L 540,90"/>
 
   <!-- Footer -->
-  <text class="note" x="840" y="538" text-anchor="end">goals flow down — insights flow back up</text>
+  <text class="note" x="20" y="618" >goals flow down — insights flow back up</text>
+  <text class="note" x="840" y="618" text-anchor="end">feedback loop: learnings compound into next cycle</text>
 </svg>

--- a/assets/images/weekly-cycle.svg
+++ b/assets/images/weekly-cycle.svg
@@ -1,0 +1,114 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 860 280" width="860" height="280">
+  <defs>
+    <style>
+      .page-bg { fill: #ffffff; }
+      .layer-bg { fill: #f6f8fa; }
+      .box { fill: #ffffff; stroke: #d0d7de; stroke-width: 1; }
+      .title { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 15px; font-weight: 700; fill: #1f2328; }
+      .subtitle { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 11px; fill: #656d76; }
+      .day-label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 10px; font-weight: 600; fill: #57606a; letter-spacing: 1px; }
+      .item-label { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 10px; font-weight: 600; fill: #1f2328; }
+      .item-desc { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 8px; fill: #656d76; }
+      .note { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; font-size: 9px; fill: #8b949e; }
+      .arrow { stroke: #b0b8c1; stroke-width: 1.2; fill: none; marker-end: url(#ah-l); }
+      .arrow-feedback { stroke: #b0b8c1; stroke-width: 1.2; fill: none; stroke-dasharray: 4 3; marker-end: url(#ah-l); }
+
+      @media (prefers-color-scheme: dark) {
+        .page-bg { fill: #0d1117; }
+        .layer-bg { fill: #161b22; }
+        .box { fill: #0d1117; stroke: #30363d; }
+        .title { fill: #e6edf3; }
+        .subtitle { fill: #8b949e; }
+        .day-label { fill: #8b949e; }
+        .item-label { fill: #e6edf3; }
+        .item-desc { fill: #8b949e; }
+        .note { fill: #484f58; }
+        .arrow { stroke: #484f58; marker-end: url(#ah-d); }
+        .arrow-feedback { stroke: #484f58; marker-end: url(#ah-d); }
+      }
+    </style>
+    <marker id="ah-l" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="none" stroke="#b0b8c1" stroke-width="1"/>
+    </marker>
+    <marker id="ah-d" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
+      <path d="M0,0 L8,3 L0,6" fill="none" stroke="#484f58" stroke-width="1"/>
+    </marker>
+  </defs>
+
+  <rect class="page-bg" width="860" height="280" rx="8"/>
+
+  <text class="title" x="430" y="20" text-anchor="middle">Compound Learning Weekly Cycle</text>
+  <text class="subtitle" x="430" y="36" text-anchor="middle">GHA monitors discover — ralphys implement — ralph self-improves — cycle repeats</text>
+
+  <!-- Timeline background -->
+  <rect class="layer-bg" x="10" y="48" width="840" height="180" rx="6"/>
+
+  <!-- Day boxes: 6 days, w=120, gap=16, total=6*120+5*16=800, start=30 -->
+
+  <!-- Mon -->
+  <text class="day-label" x="90" y="66" text-anchor="middle">MON</text>
+  <rect class="box" x="30" y="74" width="120" height="56" rx="5"/>
+  <text class="item-label" x="90" y="92" text-anchor="middle">GHA monitors</text>
+  <text class="item-desc" x="90" y="106" text-anchor="middle">cc-changelog 09:00</text>
+  <text class="item-desc" x="90" y="118" text-anchor="middle">community 10:00</text>
+
+  <!-- Wed -->
+  <text class="day-label" x="226" y="66" text-anchor="middle">WED</text>
+  <rect class="box" x="166" y="74" width="120" height="56" rx="5"/>
+  <text class="item-label" x="226" y="92" text-anchor="middle">research-ralphy</text>
+  <text class="item-desc" x="226" y="106" text-anchor="middle">triage → PRD → TDD</text>
+  <text class="item-desc" x="226" y="118" text-anchor="middle">writeback learnings</text>
+
+  <!-- Thu -->
+  <text class="day-label" x="362" y="66" text-anchor="middle">THU</text>
+  <rect class="box" x="302" y="74" width="120" height="56" rx="5"/>
+  <text class="item-label" x="362" y="92" text-anchor="middle">learnings-ralphy</text>
+  <text class="item-desc" x="362" y="106" text-anchor="middle">patterns → PRD → TDD</text>
+  <text class="item-desc" x="362" y="118" text-anchor="middle">writeback learnings</text>
+
+  <!-- Fri -->
+  <text class="day-label" x="498" y="66" text-anchor="middle">FRI</text>
+  <rect class="box" x="438" y="74" width="120" height="56" rx="5"/>
+  <text class="item-label" x="498" y="92" text-anchor="middle">ralph self-improve</text>
+  <text class="item-desc" x="498" y="106" text-anchor="middle">digest offspring</text>
+  <text class="item-desc" x="498" y="118" text-anchor="middle">self-PRD → TDD</text>
+
+  <!-- Sat -->
+  <text class="day-label" x="634" y="66" text-anchor="middle">SAT</text>
+  <rect class="box" x="574" y="74" width="120" height="56" rx="5"/>
+  <text class="item-label" x="634" y="92" text-anchor="middle">submodule update</text>
+  <text class="item-desc" x="634" y="106" text-anchor="middle">offspring pull</text>
+  <text class="item-desc" x="634" y="118" text-anchor="middle">improved ralph</text>
+
+  <!-- Next Mon -->
+  <text class="day-label" x="770" y="66" text-anchor="middle">NEXT MON</text>
+  <rect class="box" x="710" y="74" width="120" height="56" rx="5"/>
+  <text class="item-label" x="770" y="92" text-anchor="middle">cycle repeats</text>
+  <text class="item-desc" x="770" y="106" text-anchor="middle">with improved</text>
+  <text class="item-desc" x="770" y="118" text-anchor="middle">loop engine</text>
+
+  <!-- Forward arrows -->
+  <line class="arrow" x1="150" y1="102" x2="166" y2="102"/>
+  <line class="arrow" x1="286" y1="102" x2="302" y2="102"/>
+  <line class="arrow" x1="422" y1="102" x2="438" y2="102"/>
+  <line class="arrow" x1="558" y1="102" x2="574" y2="102"/>
+  <line class="arrow" x1="694" y1="102" x2="710" y2="102"/>
+
+  <!-- Data flow labels -->
+  <text class="item-desc" x="158" y="146" text-anchor="middle">triage/</text>
+  <text class="item-desc" x="294" y="146" text-anchor="middle">learnings</text>
+  <text class="item-desc" x="430" y="146" text-anchor="middle">learnings</text>
+  <text class="item-desc" x="566" y="146" text-anchor="middle">PR</text>
+  <text class="item-desc" x="702" y="146" text-anchor="middle">submodule</text>
+
+  <!-- Feedback arrow -->
+  <path class="arrow-feedback" d="M 770,130 L 770,200 L 90,200 L 90,130"/>
+
+  <text class="note" x="430" y="214" text-anchor="middle">feedback: learnings compound into next cycle via ai-agents-research hub</text>
+
+  <!-- Learnings sync callout -->
+  <rect class="box" x="280" y="230" width="300" height="28" rx="5"/>
+  <text class="item-label" x="430" y="249" text-anchor="middle">make learnings_sync — bridges local CC data to git</text>
+
+  <text class="note" x="430" y="272" text-anchor="middle">run locally before Thu to feed learnings-ralphy with latest CC session patterns</text>
+</svg>

--- a/docs/project-workflows.md
+++ b/docs/project-workflows.md
@@ -1,0 +1,199 @@
+# Project Workflows
+
+Unified decision flow for intra-project execution and inter-project orchestration.
+
+## Multi-Repo Agent Architecture
+
+CC agents load context from the repo they run in — CLAUDE.md, settings, rules, hooks,
+and plugins are per-repo. Cross-repo work requires separate sessions.
+
+<details>
+<summary>Per-repo isolation model and 5 bridges across sessions</summary>
+
+<img src="../assets/images/agent-architecture.svg" alt="Multi-Repo Agent Architecture" width="100%" />
+
+</details>
+
+```text
+Orchestrator (polyforge)
+│
+├─ spawns agent in repo-A/    → loads repo-A/.claude/*, CLAUDE.md, hooks
+├─ spawns agent in repo-B/    → loads repo-B/.claude/*, CLAUDE.md, hooks
+└─ spawns agent in repo-C/    → loads repo-C/.claude/*, CLAUDE.md, hooks
+    │
+    ├─ agents can READ files across repos (additionalDirectories)
+    └─ agents do NOT get other repos' CLAUDE.md, rules, hooks, or plugins
+```
+
+**Constraints:**
+
+- Per-repo session = full project context (CLAUDE.md, hooks, plugins fire correctly)
+- Single session with `additionalDirectories` = only main repo's context loads
+- Subagents inherit parent's context, not the target repo's
+
+**Bridges across sessions:**
+
+| Bridge | Direction | What it carries |
+| ------ | --------- | --------------- |
+| Prompt templates | Orchestrator → agent | Cross-repo context (targets, issues, skills, priorities) |
+| Git state | Agent → orchestrator | Commits, branches, PRs (read via status scripts) |
+| Compound learnings | Agent ↔ agent | Shared patterns via ai-agents-research/docs/learnings/ |
+| CC plans | Session → session | Decisions persist at ~/.claude/plans/, loaded on next session |
+| CC memory | Session → session | Per-project MEMORY.md, auto-loaded on conversation start |
+
+**Design implications:**
+
+- Prompt templates are the primary cross-repo context injection mechanism
+- Per-repo CLAUDE.md stays lean (repo-specific only, not orchestration-level)
+- Compound learnings hub (ai-agents-research) is the shared state store
+- `learnings_sync` bridges local CC session data to the git-committed hub
+- Results aggregate via git, not shared memory
+
+## Decision Flow
+
+<details>
+<summary>Route tasks by scope: multi-repo → Plan Mode → Ralph → Agent Teams → interactive</summary>
+
+<img src="../assets/images/decision-flow.svg" alt="Workflow Decision Flow" width="100%" />
+
+</details>
+
+```text
+Task arrives
+│
+├─ Spans multiple repos?
+│   → Inter-project workflow (see below)
+│   → polyforge cc-parallel.sh for batch operations
+│   → contrib preset for external fork targets
+│
+├─ Research / multi-approach design?
+│   → CC Plan Mode (EnterPlanMode tool)
+│   → Explore subagents for parallel codebase research
+│   → Plan file persists at .claude/plans/ for handoff
+│
+├─ New repo or major feature (5+ files, clear stories)?
+│   → PRD.md → Ralph submodule → make ralph_run (N_WT=1)
+│   → Ralph uses lang-dev + tdd-core skills internally
+│   │
+│   ├─ Stories independent (no shared files)?
+│   │   → Ralph teams mode (N_WT=3-5) OR CC Agent Teams
+│   │
+│   └─ Stories sequential?
+│       → Ralph single worker (N_WT=1)
+│
+├─ Parallel subtasks within a conversation?
+│   → CC Agent Teams (spawn teammates for independent work)
+│   → OR Agent tool with subagent_type (lighter, no worktree)
+│
+├─ Small feature / bug fix (1-3 files)?
+│   → CC interactive + skills (no Ralph, no plan mode)
+│
+└─ Documentation?
+    → CC interactive + docs-governance skill
+```
+
+## Intra-Project: Ralph Teams vs CC Agent Teams
+
+| Aspect | Ralph Teams (N_WT>1) | CC Agent Teams |
+| ------ | -------------------- | -------------- |
+| Orchestration | Bash scripts (parallel_ralph.sh) | CC-native lead/teammate |
+| Isolation | Git worktrees | Git worktrees (v2.1.49+) |
+| Communication | Shared prd.json + git | Mailbox messaging (SendMessage) |
+| Quality gate | `make validate` per story | TeammateIdle/TaskCompleted hooks |
+| TDD enforcement | Mandatory (commit markers) | Via tdd-core rules (advisory) |
+| Plan approval | No | Yes — teammates plan, lead approves |
+| Best for | Automated batch implementation | Interactive multi-agent collaboration |
+
+## Inter-Project: Multi-Repo Contribution
+
+### Fork Workflow
+
+External contributions follow fork-first:
+
+1. Fork upstream repo under your account
+2. Clone your fork locally
+3. Add upstream remote (`git remote add upstream`)
+4. Branch, implement (TDD), push to fork, PR to upstream
+
+### Contribution Phases
+
+**Triage** — explore codebase, assess issue complexity, post analysis comment on upstream.
+
+**Implement** — strict TDD (Red-Green-Refactor), create branch, conventional commits, PR to upstream.
+
+**Review** — check out open PR, review diff, run tests, post comment-only review.
+
+### Parallel Execution
+
+Independent repos can be worked on simultaneously — each gets its own agent session with per-project config (tech stack, skills, upstream target, default issues).
+
+### Contribution Targets
+
+**OSS Projects:**
+
+| Project | Stack | Key Issues |
+| ------- | ----- | ---------- |
+| CraftsMan-Labs/SimpleAgents | Rust | #23 (complexity CI), #42 (approval), #44 (CC skills) |
+| richlira/compass-mcp | TypeScript | Tests+CI, list_contexts, agent identity |
+| Gitlawb/openclaude | TypeScript | PR#268 (3P params), PR#278 (gRPC), PR#218 (router) |
+| OpenClaudia/openclaudia-skills | JS/Markdown | #7 (descriptions), #2 (CI validation) |
+
+**patent-dev (Go):**
+
+| Project | Key Issues |
+| ------- | ---------- |
+| patent-dev/epo-ops | #1 (proxy cache), #2 (XML parsing) |
+| patent-dev/bulk-file-loader | Test coverage, docs |
+| patent-dev/uspto-odp | Test coverage, docs |
+| patent-dev/dpma-connect-plus | Test coverage, docs |
+| patent-dev/epo-bdds | Test coverage, docs |
+
+### Priority Matrix
+
+```text
+IMMEDIATE (trust builders, all parallelizable)
+├── SimpleAgents #23 (complexity CI)
+├── compass-mcp tests+CI+list_contexts
+├── openclaude PR#268 review
+├── openclaudia #7+#2
+└── patent-dev epo-ops #1+#2
+
+SHORT-TERM (high value)
+├── SimpleAgents #42 (approval system)
+├── compass-mcp agent identity + multi-workspace
+├── openclaude PR#361 (rate limiting)
+└── openclaudia release-notes skill
+
+STRATEGIC (steer direction)
+├── SimpleAgents #44 (CC skills interop)
+├── compass-mcp change notifications
+├── openclaude PR#278+#218 (gRPC+router)
+└── openclaudia manifest standardization
+```
+
+## Compound Learning
+
+<details>
+<summary>Mon monitors → Wed/Thu ralphys implement → Fri ralph self-improves → cycle repeats</summary>
+
+<img src="../assets/images/weekly-cycle.svg" alt="Compound Learning Weekly Cycle" width="100%" />
+
+</details>
+
+### Learnings Sync
+
+Local CC session data → distilled learnings → committed to git → ralphys consume:
+
+```bash
+make learnings_sync   # bigpicture + plan-learnings → ai-agents-research
+```
+
+### Self-Evolution Cycle
+
+```text
+Mon    GHA monitors discover (ai-agents-research)
+Wed    research-ralphy: discoveries → PRD → TDD → writeback
+Thu    learnings-ralphy: patterns → PRD → TDD → writeback
+Fri    ralph self-improve: digest offspring → self-PRD → TDD
+Sat    offspring update ralph submodule
+```


### PR DESCRIPTION
## Summary
- **architecture.svg**: 22 → 32 repos across 8 layers (was 6)
  - Added: ralphys, gha-repo-index, biorxiv-stats, so101-biolab, agenthud, cc-voice, eyerest, cc-recursive-team
  - New layers: Agent UI/Voice/Robotics, reorganized Infrastructure & Plugins
- **toolchain-layers.svg**: Added Self-Evolving Agents layer + feedback arrow
  - learnings-ralphy + research-ralphy between Autonomous Execution and Insight Capture
  - Dashed feedback arrow: insights flow back to goals
- **README.md**: Added topics for self-evolving agents, GHA pipeline taxonomy, agent UI/voice, robotics

## Test plan
- [ ] Verify SVGs render correctly in light mode
- [ ] Verify SVGs render correctly in dark mode
- [ ] Verify all repo links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)