### PR TITLE
feat: add repo registry workflow

### DIFF
--- a/.github/workflows/repo-registry.yml
+++ b/.github/workflows/repo-registry.yml
@@ -1,0 +1,23 @@
+---
+name: Update Repo Registry
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly, Monday 6am UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  models: read
+
+jobs:
+  update-registry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: qte77/gha-repo-index@main
+        with:
+          OWNER: qte77
+          OUTPUT_DIR: registry
+          CREATE_PR: "true"


### PR DESCRIPTION
## Summary

- Adds calling workflow for `qte77/gha-repo-index@main`
- Schedule: weekly Monday 6am UTC + manual dispatch
- Permissions: `contents:write`, `pull-requests:write`, `models:read`
- Outputs `registry/index.json` + `REPO_REGISTRY.md` to this repo

## Test plan

- [ ] Merge qte77/gha-repo-index#1 first
- [ ] Run `workflow_dispatch` to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)