### PR TITLE
fix: remove arxiv/biorxiv from architecture.svg

### DIFF
--- a/assets/images/architecture.svg
+++ b/assets/images/architecture.svg
@@ -150,71 +150,57 @@
     <text class="repo-desc" x="815" y="250" text-anchor="middle">3-tier MAS evaluation</text>
   </a>
 
-  <!-- ===== Layer 4: GitHub Actions (9 boxes, w=88, gap=7, start=26) ===== -->
+  <!-- ===== Layer 4: GitHub Actions (7 boxes, w=112, gap=10, start=28) ===== -->
   <rect class="layer-bg" x="10" y="278" width="880" height="74" rx="6"/>
   <text class="layer-label" x="20" y="292">GITHUB ACTIONS</text>
 
   <a xlink:href="https://github.com/qte77/gha-repo-index">
     <title>gha-repo-index — Registry SOT: indexes all repos into registry/index.json</title>
-    <rect class="box" x="26" y="296" width="88" height="48" rx="5"/>
-    <text class="repo-name" x="70" y="315" text-anchor="middle">repo-index</text>
-    <text class="repo-desc" x="70" y="330" text-anchor="middle">registry SOT</text>
+    <rect class="box" x="28" y="296" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="84" y="315" text-anchor="middle">repo-index</text>
+    <text class="repo-desc" x="84" y="330" text-anchor="middle">registry SOT</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-ai-changelog">
     <title>gha-ai-changelog — AI-powered changelog generation from PRs</title>
-    <rect class="box" x="121" y="296" width="88" height="48" rx="5"/>
-    <text class="repo-name" x="165" y="315" text-anchor="middle">ai-changelog</text>
-    <text class="repo-desc" x="165" y="330" text-anchor="middle">AI changelogs</text>
+    <rect class="box" x="150" y="296" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="206" y="315" text-anchor="middle">ai-changelog</text>
+    <text class="repo-desc" x="206" y="330" text-anchor="middle">AI changelogs</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-contribution-ascii">
     <title>gha-contribution-ascii — Write ASCII art onto GitHub contribution graph</title>
-    <rect class="box" x="216" y="296" width="88" height="48" rx="5"/>
-    <text class="repo-name" x="260" y="315" text-anchor="middle">contrib-ascii</text>
-    <text class="repo-desc" x="260" y="330" text-anchor="middle">graph art</text>
+    <rect class="box" x="272" y="296" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="328" y="315" text-anchor="middle">contrib-ascii</text>
+    <text class="repo-desc" x="328" y="330" text-anchor="middle">graph art</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-dirtree-to-readme">
     <title>gha-dirtree-to-readme — Auto-insert directory tree into README</title>
-    <rect class="box" x="311" y="296" width="88" height="48" rx="5"/>
-    <text class="repo-name" x="355" y="315" text-anchor="middle">dirtree-readme</text>
-    <text class="repo-desc" x="355" y="330" text-anchor="middle">dir tree sync</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/gha-arxiv-stats-action">
-    <title>gha-arxiv-stats-action — Logs daily stats of papers submitted to arxiv.org</title>
-    <rect class="box" x="406" y="296" width="88" height="48" rx="5"/>
-    <text class="repo-name" x="450" y="315" text-anchor="middle">arxiv-stats</text>
-    <text class="repo-desc" x="450" y="330" text-anchor="middle">arXiv papers</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/gha-biorxiv-stats-action">
-    <title>gha-biorxiv-stats-action — Logs daily stats of papers submitted to biorxiv.org</title>
-    <rect class="box" x="501" y="296" width="88" height="48" rx="5"/>
-    <text class="repo-name" x="545" y="315" text-anchor="middle">biorxiv-stats</text>
-    <text class="repo-desc" x="545" y="330" text-anchor="middle">bioRxiv papers</text>
+    <rect class="box" x="394" y="296" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="450" y="315" text-anchor="middle">dirtree-readme</text>
+    <text class="repo-desc" x="450" y="330" text-anchor="middle">dir tree sync</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-cross-repo-issue-sync">
     <title>gha-cross-repo-issue-sync — Synchronize issues across repositories</title>
-    <rect class="box" x="596" y="296" width="88" height="48" rx="5"/>
-    <text class="repo-name" x="640" y="315" text-anchor="middle">issue-sync</text>
-    <text class="repo-desc" x="640" y="330" text-anchor="middle">cross-repo issues</text>
+    <rect class="box" x="516" y="296" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="572" y="315" text-anchor="middle">issue-sync</text>
+    <text class="repo-desc" x="572" y="330" text-anchor="middle">cross-repo issues</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-arbitrary-repo-timeline">
     <title>gha-arbitrary-repo-timeline — Generate timeline visualizations for any repo</title>
-    <rect class="box" x="691" y="296" width="88" height="48" rx="5"/>
-    <text class="repo-name" x="735" y="315" text-anchor="middle">repo-timeline</text>
-    <text class="repo-desc" x="735" y="330" text-anchor="middle">timeline viz</text>
+    <rect class="box" x="638" y="296" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="694" y="315" text-anchor="middle">repo-timeline</text>
+    <text class="repo-desc" x="694" y="330" text-anchor="middle">timeline viz</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-github-mirror-action">
     <title>gha-github-mirror-action — Mirror repositories across platforms</title>
-    <rect class="box" x="786" y="296" width="88" height="48" rx="5"/>
-    <text class="repo-name" x="830" y="315" text-anchor="middle">github-mirror</text>
-    <text class="repo-desc" x="830" y="330" text-anchor="middle">repo mirroring</text>
+    <rect class="box" x="760" y="296" width="112" height="48" rx="5"/>
+    <text class="repo-name" x="816" y="315" text-anchor="middle">github-mirror</text>
+    <text class="repo-desc" x="816" y="330" text-anchor="middle">repo mirroring</text>
   </a>
 
   <!-- ===== Layer 5: Infrastructure & Plugins (4 boxes, w=190, gap=20, start=40) ===== -->
@@ -287,5 +273,5 @@
 
   <!-- Footer -->
   <text class="note" x="20" y="572">* pat-tax/ org</text>
-  <text class="note" x="880" y="572" text-anchor="end">32 repositories</text>
+  <text class="note" x="880" y="572" text-anchor="end">30 repositories</text>
 </svg>


### PR DESCRIPTION
## Summary
Remove arxiv-stats and biorxiv-stats from architecture.svg — they belong in the OBSERVE layer of pipeline-layers.svg, not the project ecosystem overview. 9→7 GHA boxes, 32→30 repos.

## Test plan
- [ ] SVG renders correctly in light/dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)