### PR TITLE
chore: rename plugin references to claude-code-plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,13 +4,13 @@
     "pr": "Generated with Claude <noreply@anthropic.com>"
   },
   "enabledPlugins": {
-    "commit-helper@qte77-claude-code-utils": true
+    "commit-helper@qte77-claude-code-plugins": true
   },
   "extraKnownMarketplaces": {
-    "qte77-claude-code-utils": {
+    "qte77-claude-code-plugins": {
       "source": {
         "source": "github",
-        "repo": "qte77/claude-code-utils-plugin"
+        "repo": "qte77/claude-code-plugins"
       }
     }
   }

--- a/assets/images/architecture.svg
+++ b/assets/images/architecture.svg
@@ -214,10 +214,10 @@
     <text class="repo-desc" x="135" y="403" text-anchor="middle">dev environment config</text>
   </a>
 
-  <a xlink:href="https://github.com/qte77/claude-code-utils-plugin">
-    <title>claude-code-utils-plugin — CC plugin marketplace with 20 plugins and 37 skills</title>
+  <a xlink:href="https://github.com/qte77/claude-code-plugins">
+    <title>claude-code-plugins — CC plugin marketplace with 26 plugins</title>
     <rect class="box" x="250" y="374" width="190" height="38" rx="5"/>
-    <text class="repo-name" x="345" y="389" text-anchor="middle">cc-utils-plugin</text>
+    <text class="repo-name" x="345" y="389" text-anchor="middle">cc-plugins</text>
     <text class="repo-desc" x="345" y="403" text-anchor="middle">20 plugins, 37 skills</text>
   </a>
 

--- a/assets/images/toolchain-layers.svg
+++ b/assets/images/toolchain-layers.svg
@@ -132,10 +132,10 @@
     <text class="repo-desc" x="310" y="500" text-anchor="middle">learnings + external input</text>
   </a>
 
-  <a xlink:href="https://github.com/qte77/claude-code-utils-plugin">
-    <title>cc-utils-plugin — Modular skills, rules, and workspace plugins</title>
+  <a xlink:href="https://github.com/qte77/claude-code-plugins">
+    <title>cc-plugins — Modular skills, rules, and workspace plugins</title>
     <rect class="box" x="450" y="466" width="200" height="48" rx="5"/>
-    <text class="repo-name" x="550" y="485" text-anchor="middle">cc-utils-plugin</text>
+    <text class="repo-name" x="550" y="485" text-anchor="middle">cc-plugins</text>
     <text class="repo-desc" x="550" y="500" text-anchor="middle">skills + rules + workspaces</text>
   </a>
 


### PR DESCRIPTION
## Summary
- Rename `claude-code-utils-plugin` → `claude-code-plugins` and `qte77-claude-code-utils` → `qte77-claude-code-plugins`

Follows GitHub repo rename qte77/claude-code-utils-plugin → qte77/claude-code-plugins.

🤖 Generated with Claude <noreply@anthropic.com>