### PR TITLE
chore: add workspace governance files + .claude rules + statusline

### DIFF
--- a/.claude/rules/compound-learning.md
+++ b/.claude/rules/compound-learning.md
@@ -1,0 +1,21 @@
+# Compound Learning
+
+Prevent repeated mistakes by systematically promoting learnings.
+
+## Before Solving a Problem
+
+Check AGENT_LEARNINGS.md for prior art. If a matching pattern exists, apply it.
+
+## Promotion Path
+
+1. **1st occurrence** — fix inline, move on
+2. **2nd occurrence** — add to AGENT_LEARNINGS.md (pattern + solution)
+3. **3rd occurrence** — promote to `.claude/rules/` (always-loaded, prevents recurrence)
+4. **Recurring workflow** — extract to `.claude/skills/` (reusable capability)
+
+## When Promoting (step 3)
+
+- Verify the root cause is the same across occurrences
+- Write the rule as a constraint ("do X", "never Y"), not a narrative
+- Reference the AGENT_LEARNINGS.md entry being promoted
+- Remove or link the original entry to avoid duplication

--- a/.claude/rules/context-management.md
+++ b/.claude/rules/context-management.md
@@ -1,0 +1,59 @@
+# Context Management (ACE-FCA)
+
+Principles for optimal context window utilization.
+
+## Context Quality Equation
+
+Quality output = Correct context + Complete context + Minimal noise
+
+## Degradation Hierarchy (worst to best)
+
+1. **Incorrect information** - worst, causes cascading errors (garbage in, garbage out)
+2. **Missing information** - leads to assumptions (agent guesses, sometimes wrong)
+3. **Excessive noise** - dilutes signal, wastes capacity (truth buried but still there)
+
+Better to have less correct info than more info with errors.
+
+## Utilization Target
+
+Keep context at **40-60%** capacity. Leave room for:
+
+- Model reasoning
+- Output generation
+- Error recovery
+
+## Context Pollution Sources (What)
+
+These mess up context - compact/summarize immediately:
+
+- File searches (glob/grep results)
+- Code flow traces
+- Edit applications
+- Test/build logs
+- Large JSON blobs from tools
+
+## Workflow Phases
+
+Research → Planning → Implementation. Compact after each phase transition.
+
+## Compaction Triggers (When)
+
+Use `compacting-context` skill when:
+
+- Verbose tool output (logs, JSON, search results)
+- After completing a phase or milestone
+- Before starting new complex task
+
+## Subagent Usage
+
+Use `researching-codebase` skill to:
+
+- Isolate discovery artifacts from main context
+- Return structured findings only
+- Prevent search noise pollution
+
+## Output Guidelines
+
+- Prefer structured summaries over raw dumps
+- Extract only relevant portions from large files
+- Use targeted searches, not broad sweeps

--- a/.claude/rules/core-principles.md
+++ b/.claude/rules/core-principles.md
@@ -1,0 +1,64 @@
+# Core Principles
+
+**MANDATORY for ALL tasks.** These principles override all other guidance when
+conflicts arise.
+
+## User-Centric Principles
+
+**User Experience, User Joy, User Success** - Every decision optimizes for
+user value, clarity, and usability.
+
+## Code Quality Principles
+
+**KISS (Keep It Simple, Stupid)** - Simplest solution that works. Clear > clever.
+
+**DRY (Don't Repeat Yourself)** - Single source of truth. Reference, don't duplicate.
+
+**YAGNI (You Aren't Gonna Need It)** - Implement only what's requested. No
+speculative features.
+
+## Execution Principles
+
+**Concise and Focused** - Minimal code/text for task. Touch only task-related code.
+
+**Reuse and Extend** - Use existing patterns and dependencies. Don't rebuild.
+
+**Prevent Incoherence** - Spot inconsistencies. Validate against existing patterns.
+
+**Resolve Ambiguity** - Clarify vague requirements before acting.
+
+## Decision Principles
+
+**Rigor and Sufficiency** - Research enough to decide confidently. No more, no less.
+
+**High-Impact Quick Wins** - Prioritize must-do tasks. Ship fast, iterate.
+
+**Actionable and Concrete** - Specific deliverables. Measurable outcomes.
+
+**Root-Cause and First-Principles** - Understand the "why". Solve root problems.
+
+## Before Starting Any Task
+
+- [ ] Does this serve user value?
+- [ ] Is this the simplest approach?
+- [ ] Am I duplicating existing work?
+- [ ] Do I actually need this?
+- [ ] Am I touching only relevant code?
+- [ ] What's the root cause I'm solving?
+
+## Post-Task Review
+
+Before finishing, ask yourself:
+
+- **Did we forget anything?** - Check requirements thoroughly
+- **High-ROI enhancements?** - Suggest opportunities (don't implement)
+- **Something to delete?** - Remove obsolete/unnecessary code
+
+**IMPORTANT**: Do NOT alter files based on this review. Only output
+suggestions to the user.
+
+## When in Doubt
+
+**STOP. Ask the user.**
+
+Don't assume, don't over-engineer, don't add complexity.

--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+input=$(cat)
+
+# Single jq call extracts all fields (tab-delimited)
+read -r cwd agent model version cost duration lines_added lines_removed \
+    tokens_in tokens_out remaining_pct exc_context <<< "$(echo "$input" | jq -r '[
+    .workspace.current_dir,
+    (.agent.type // "main"),
+    .model.id,
+    (.version // ""),
+    (if .cost.total_cost_usd then (.cost.total_cost_usd * 100 | round / 100 | tostring) + "$" else "" end),
+    (((.cost.total_api_duration_ms // 0) / 1000 / 60 | round | tostring) + "m"),
+    (.cost.total_lines_added // 0 | tostring),
+    (.cost.total_lines_removed // 0 | tostring),
+    (((.context_window.total_input_tokens // 0) / 1000 | floor | tostring) + "k"),
+    (((.context_window.total_output_tokens // 0) / 1000 | floor | tostring) + "k"),
+    (if .context_window.current_usage.input_tokens then
+        (.context_window.context_window_size // 200000) as $win |
+        (.context_window.current_usage.input_tokens // 0) as $in |
+        (.context_window.current_usage.cache_creation_input_tokens // 0) as $cc |
+        (.context_window.current_usage.cache_read_input_tokens // 0) as $cr |
+        (($in + $cc + $cr) / $win * 100) as $used |
+        (100 - $used) | round
+    else
+        .context_window.remaining_percentage // 100
+    end | tostring),
+    (.exceeds_200k_tokens // false | tostring)
+] | join("\t")')"
+
+lines_changed="+${lines_added}/-${lines_removed}"
+tokens="${tokens_in}/${tokens_out}"
+
+# Subtract autocompact buffer to get TRUE usable space
+# Priority: env var > observed default (16.5%)
+if [ -n "$CLAUDE_AUTOCOMPACT_PCT_OVERRIDE" ]; then
+    AUTOCOMPACT_BUFFER_PCT=$(awk "BEGIN {print 100 - $CLAUDE_AUTOCOMPACT_PCT_OVERRIDE}")
+else
+    # Docs claim CLAUDE_AUTOCOMPACT_PCT_OVERRIDE default is 95% (5% buffer),
+    # but /context shows 16.5% buffer and compaction triggers at ~78-85% (issues #18264, #18241).
+    # FIXME: Using observed 16.5% until Claude Code fixes the discrepancy.
+    AUTOCOMPACT_BUFFER_PCT=16.5
+fi
+
+true_free_pct=$(awk "BEGIN {print $remaining_pct - $AUTOCOMPACT_BUFFER_PCT}")
+remaining=$(echo "$true_free_pct" | awk '{printf "%.2f", $1/100}' | sed 's/^0\./\./')
+
+# Color remaining based on TRUE free space threshold (warn when running LOW)
+if [ $(awk "BEGIN {print ($true_free_pct <= 10)}") -eq 1 ]; then
+    ctx_color="\\033[93;41m"  # Bright yellow fg, red bg - CRITICAL (≤10% usable)
+elif [ $(awk "BEGIN {print ($true_free_pct <= 20)}") -eq 1 ]; then
+    ctx_color="\\033[91;48;5;237m"  # Bright red fg, dark gray bg - WARNING (≤20% usable)
+elif [ $(awk "BEGIN {print ($true_free_pct <= 35)}") -eq 1 ]; then
+    ctx_color="\\033[93m"  # Yellow fg - CAUTION (≤35% usable)
+else
+    ctx_color="\\033[0;32m"   # Normal green fg - OK
+fi
+
+user=$(whoami)
+time=$(date +%H:%M:%S)
+
+if git rev-parse --git-dir >/dev/null 2>&1; then
+    branch=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null)
+    else branch=""
+fi
+
+printf "\\033[0;31magent:%s \\033[0;33mmodel:%s \\033[2mver:%s \\033[0;34mcost:%s \\033[0;36mdur:%s\\n\\033[0;32mlines:%s \\033[2mtokens(i/o):%s ${ctx_color}ctx(free):%s\\033[0m \\033[0;31m>200k:%s\\033[0m\\n\\033[2mdir:%s \\033[0;36mbranch:%s \\033[0;32muser:%s \\033[0;35mtime:%s\\033[0m" "$agent" "$model" "$version" "$cost" "$duration" "$lines_changed" "$tokens" "$remaining" "$exc_context" "$(basename "$cwd")" "$branch" "$user" "$time"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,110 @@
+# Agent Instructions
+
+**Behavioral rules, compliance requirements, and decision frameworks for AI coding
+agents.** For technical workflows and coding standards, see
+[CONTRIBUTING.md](CONTRIBUTING.md). For project overview, see
+[README.md](README.md).
+
+**External References:**
+
+- @CONTRIBUTING.md - Command reference, testing guidelines, code style patterns
+- @AGENT_REQUESTS.md - Escalation and human collaboration
+- @AGENT_LEARNINGS.md - Pattern discovery and knowledge sharing
+
+## Claude Code Infrastructure
+
+**Rules** (`.claude/rules/`): Session-loaded constraints (always active)
+**Skills** (`.claude/skills/`): Modular capabilities with progressive disclosure
+
+## Core Rules & AI Behavior
+
+- Follow SDLC principles: maintainability, modularity, reusability, adaptability
+- **Never assume missing context** - Ask questions if uncertain about requirements
+- **Never hallucinate libraries** - Only use packages verified in project dependencies
+- **Always confirm file paths exist** before referencing in code or tests
+- **Never delete existing code** unless explicitly instructed or documented refactoring
+- **Document new patterns** in AGENT_LEARNINGS.md (concise, laser-focused, streamlined)
+- **Request human feedback** in AGENT_REQUESTS.md (concise, laser-focused, streamlined)
+
+## Decision Framework
+
+**Priority Order:** User instructions > AGENTS.md compliance > Documentation
+hierarchy > Project patterns > General best practices
+
+**Anti-Scope-Creep Rules:**
+
+- **NEVER implement features without requirement validation**
+- **Always validate implementation decisions against project scope boundaries**
+
+**Anti-Redundancy Rules:**
+
+- **NEVER duplicate information across documents** - reference authoritative sources
+- **Update authoritative document, then remove duplicates elsewhere**
+
+**When to Escalate to AGENT_REQUESTS.md:**
+
+- User instructions conflict with safety/security practices
+- AGENTS.md rules contradict each other
+- Required information completely missing
+- Actions would significantly change project architecture
+
+## Agent Neutrality Requirements
+
+**ALL AI AGENTS MUST MAINTAIN STRICT NEUTRALITY AND REQUIREMENT-DRIVEN DESIGN:**
+
+1. **Extract requirements from specified documents ONLY**
+   - Read provided task descriptions or reference materials
+   - Do NOT make assumptions about unstated requirements
+   - Do NOT add functionality not explicitly requested
+
+2. **Request clarification for ambiguous scope**
+   - If task boundaries are unclear, ASK for clarification
+   - If complexity level is not specified, ASK for target complexity
+   - Do NOT assume scope or make architectural decisions without validation
+
+3. **Design to stated requirements exactly**
+   - Match the complexity level requested
+   - Follow "minimal," "streamlined," or "focused" guidance literally
+   - Do NOT over-engineer solutions beyond stated needs
+
+## Compliance Requirements
+
+1. **Command Execution**: Use project make recipes or standard tooling
+2. **Quality Validation**: Run validation before task completion; fix ALL issues
+3. **Coding Style**: Follow existing project patterns and conventions
+4. **Documentation Updates**: Update docs when introducing new patterns
+5. **Testing**: Create tests for new functionality
+6. **Code Standards**: Use absolute imports, add `# Reason:` comments for complex logic
+
+## Quality Thresholds
+
+**Before starting any task, ensure:**
+
+- **Context**: 8/10 - Understand requirements, codebase patterns, dependencies
+- **Clarity**: 7/10 - Clear implementation path and expected outcomes
+- **Alignment**: 8/10 - Follows project patterns and architectural decisions
+- **Success**: 7/10 - Confident in completing task correctly
+
+### Below Threshold Action
+
+Gather more context or escalate to AGENT_REQUESTS.md
+
+## Agent Quick Reference
+
+**Pre-Task:**
+
+- Read AGENTS.md > CONTRIBUTING.md for technical details
+- Verify quality thresholds met
+
+**During Task:**
+
+- Use project commands (document deviations)
+- Follow existing patterns and conventions
+- Update documentation when learning patterns
+
+**Post-Task:**
+
+- Run validation - must pass all checks (code tasks only)
+- Update CHANGELOG.md for non-trivial changes
+- Document new patterns in AGENT_LEARNINGS.md (concise, laser-focused, streamlined)
+- Escalate to AGENT_REQUESTS.md if blocked

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -1,0 +1,14 @@
+---
+title: Agent Learning Documentation
+description: Non-obvious patterns that prevent repeated mistakes across sprints
+---
+
+## Template
+
+- **Context**: When/where this applies
+- **Problem**: What issue this solves
+- **Solution**: Implementation approach
+- **Example**: Working code
+- **References**: Related files
+
+## Learned Patterns

--- a/AGENT_REQUESTS.md
+++ b/AGENT_REQUESTS.md
@@ -1,0 +1,18 @@
+---
+title: Agent Requests to Humans
+description: Escalation protocol and active requests requiring human decision
+---
+
+**Always escalate when:**
+
+- User instructions conflict with safety/security practices
+- Rules contradict each other
+- Required information completely missing
+- Actions would significantly change project architecture
+- Critical dependencies unavailable
+
+**Format:** `- [ ] [PRIORITY] Description` with Context, Problem, Files, Alternatives, Impact
+
+## Active Requests
+
+None.


### PR DESCRIPTION
## Summary

Replaces #34 (incoherent — body claimed persistence-layer SVG, actual diff was governance bundle). Cherry-picked the two keepable commits onto post-#37 main; dropped:

- \`0cfb7f3\` (persistence-layer SVG) — already reverted; target SVG \`toolchain-layers.svg\` no longer exists after #37
- \`11568a4\` (claude-code-utils-plugin → claude-code-plugins rename) — already merged via #33

## What ships

- \`AGENTS.md\`, \`AGENT_LEARNINGS.md\`, \`AGENT_REQUESTS.md\` — workspace governance trio
- \`.claude/rules/\` — compound-learning, context-management, core-principles
- \`.claude/scripts/statusline.sh\` — Claude Code statusline script

## Closes / replaces

Closes #34 (intent-correct subset of its work)
Refs #41 (deferred: persistence layer revisit)

## Test plan

- [ ] Files exist on the branch (verified: 2 commits, 7 files)
- [ ] No conflicts with main after #37 merged (verified: cherry-pick was clean)