### PR TITLE
docs(readme): add Lineage section linking to context-engineering-template-legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,7 @@ Goal-driven development with AI agents — from specs to merged PRs across dev a
 - [x] Kaggle Competitions
 - [ ] Codewars Python
 - [ ] AdventOfcode
+
+## Lineage
+
+The spec-generation pillar (RAPID) descends from [`context-engineering-template-legacy`](https://github.com/qte77/context-engineering-template-legacy) (created 2025-07-06; CABIO vision introduced 2025-08-11), where the BRD → PRD → FRP pipeline originated. That repo is reference-only; active work lives in [`RAPID-spec-forge`](https://github.com/qte77/RAPID-spec-forge).


### PR DESCRIPTION
## Summary
- Add `## Lineage` section at the bottom of README.md
- Document provenance of the RAPID spec pillar: descends from `context-engineering-template-legacy`
- Note dated origins: legacy created 2025-07-06; CABIO vision introduced 2025-08-11
- Direct readers to active successor `RAPID-spec-forge`

## Test plan
- [ ] Render README on GitHub and confirm the Lineage section appears at the bottom
- [ ] Verify both repo links resolve

Generated with Claude <noreply@anthropic.com>