### PR TITLE
chore(settings): enable workspace-setup and docs-governance plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,9 @@
     "pr": "Generated with Claude <noreply@anthropic.com>"
   },
   "enabledPlugins": {
-    "commit-helper@qte77-claude-code-plugins": true
+    "commit-helper@qte77-claude-code-plugins": true,
+    "workspace-setup@qte77-claude-code-plugins": true,
+    "docs-governance@qte77-claude-code-plugins": true
   },
   "extraKnownMarketplaces": {
     "qte77-claude-code-plugins": {


### PR DESCRIPTION
## Summary
- Marketplace `qte77-claude-code-plugins` is already registered in `.claude/settings.json`
- Enable two additional plugins that deliver the canonical rule layer and governance tooling:
  - `workspace-setup`: deploys `.claude/rules/`, statusline, governance files, base settings, read-once dedup hook
  - `docs-governance`: `enforcing-doc-hierarchy`, `maintaining-agents-md`, plus the new `templates/` skeleton (claude-code-plugins#131)
- Committed `.claude/rules/` files remain as offline fallback per earlier decision

## Why
Completes the consumer side of the plugin-distribution model: claude-code-plugins is canonical for rules/skills; this repo consumes via marketplace install. Pairs with claude-code-plugins#129 / #130 / #131.

## Test plan
- [ ] After merge, `claude plugin list` in this repo shows commit-helper + workspace-setup + docs-governance installed
- [ ] Rules from workspace-setup load without conflict against the committed `.claude/rules/` fallback

Generated with Claude <noreply@anthropic.com>