### PR TITLE
docs(agents): codify AR-vs-Issue policy; track tracker FIXME as #54

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,21 @@ hierarchy > Project patterns > General best practices
 - Required information completely missing
 - Actions would significantly change project architecture
 
+## AR vs GitHub Issue
+
+`AGENT_REQUESTS.md` is for **ephemeral session-level escalations only** —
+something an agent surfaces *during* a session that needs human input *now* or
+*this session*. Once resolved (typically within a session or two), the entry
+is removed.
+
+Anything that will outlive the current session — long-running decisions,
+multi-step migrations, blockers requiring multiple discussions — must
+graduate to a **GitHub Issue**. Per the task-tracking authority chain,
+GitHub Issues are the source of truth for persistent state.
+
+If an AR entry persists beyond a few sessions, file it as an Issue and
+remove the AR entry.
+
 ## Agent Neutrality Requirements
 
 **ALL AI AGENTS MUST MAINTAIN STRICT NEUTRALITY AND REQUIREMENT-DRIVEN DESIGN:**


### PR DESCRIPTION
## Summary
Per the task-tracking authority chain (GitHub Issues = source of truth), `AGENT_REQUESTS.md` holds only ephemeral session-level escalations. Anything outliving a session must graduate to a GitHub Issue.

This PR:
- Adds an **AR vs GitHub Issue** section to `AGENTS.md` codifying the distinction
- Reverts the FIXME entry from `AGENT_REQUESTS.md` (originally added in this branch — was the wrong vehicle)
- Re-files that FIXME concern as **#54** (the persistent tracker is now the authoritative home)

## Why
The original PR violated the very policy it was trying to surface — filing a long-lived blocker in AR. This amendment fixes both the symptom (move FIXME to #54) and the root cause (codify the policy so future agents don't repeat the misuse).

## Net diff
- `AGENTS.md`: +14 lines (new section)
- `AGENT_REQUESTS.md`: 0 net change (FIXME entry removed = back to "None.")
- New issue: #54

## Test plan
- [ ] Render AGENTS.md — new "AR vs GitHub Issue" section appears between Decision Framework and Agent Neutrality Requirements
- [ ] AGENT_REQUESTS.md shows "Active Requests: None."
- [ ] #54 captures the FIXME with full Context/Problem/Alternatives/Impact

Generated with Claude <noreply@anthropic.com>