### PR TITLE
docs: refresh ecosystem diagrams and README hero/architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,17 @@ Goal-driven development with AI agents — from specs to merged PRs across dev a
 
 ## Mental Model
 
+Agentic development across 30+ repos drifts without a shared map. This fixes the feedback loop from learnings back to specs so the system compounds instead of forgetting.
+
 <img src="assets/images/mental-model.svg" alt="qte77 Mental Model — clusters, flow, feedback loop" width="100%" />
 
-### GHA Pipeline
+### Authority Chain
 
-<img src="assets/images/pipeline-layers.svg" alt="GHA Automation Pipeline" width="100%" />
+Policy, mechanism, and state get confused and duplicated across repos. Naming where each decision lives prevents the drift and keeps 30+ repos DRY.
+
+<img src="assets/images/authority-chain.svg" alt="qte77 Authority Chain — META, KERNEL, MECHANISM, STATE, CONSUMERS" width="100%" />
+
+See also: [GHA automation pipeline](assets/images/pipeline-layers.svg) — the 13 GitHub Actions running across the ecosystem.
 
 ## Topics
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
   <img src="brand/images/logo-wordmark.paths.dejavu.svg" alt="qte77" width="100%" />
 </p>
 
-Goal-driven development with AI agents — from specs to merged PRs across dev and office repos. RAPID generates specs, Ralph implements via TDD, Polyforge and Office-forge orchestrate across repos, issues sync cross-repo, progress traces back to goals.
+Turn goals into merged PRs across many repos at once. Agents handle dev and office work end to end, in parallel.
 
-> This ecosystem connects a goal artifact through spec generation, autonomous implementation, cross-repo coordination, and traceability — end to end.
+> Without coordination, agentic work across many repos drifts — learnings get lost, work duplicates, goals lose their thread. qte77 keeps the goal → spec → build → learn loop compounding, not forgetting.
 
 ## Mental Model
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <!-- https://github.com/DavidAnson/markdownlint/blob/v0.25.1/doc/Rules.md#md033 -->
 
 <p align="center">
-  <img src="brand/images/logo-wordmark.paths.dejavu.svg" alt="qte77" width="320" />
+  <img src="brand/images/logo-wordmark.paths.dejavu.svg" alt="qte77" width="100%" />
 </p>
 
 Goal-driven development with AI agents — from specs to merged PRs across dev and office repos. RAPID generates specs, Ralph implements via TDD, Polyforge and Office-forge orchestrate across repos, issues sync cross-repo, progress traces back to goals.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Policy, mechanism, and state get confused and duplicated across repos. Naming wh
 
 <img src="assets/images/authority-chain.svg" alt="qte77 Authority Chain — META, KERNEL, MECHANISM, STATE, CONSUMERS" width="100%" />
 
-See also: [GHA automation pipeline](assets/images/pipeline-layers.svg) — the 13 GitHub Actions running across the ecosystem.
+See also: [GHA automation pipeline](assets/images/pipeline-layers.svg) — the GitHub Actions running across the ecosystem.
 
 ## Topics
 

--- a/assets/images/authority-chain.svg
+++ b/assets/images/authority-chain.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 900 420" width="900" height="420">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 900 660" width="900" height="660">
   <defs>
     <style>
       .page-bg { fill: #ffffff; }
@@ -38,15 +38,15 @@
     </marker>
   </defs>
 
-  <rect class="page-bg" width="900" height="420" rx="8"/>
+  <rect class="page-bg" width="900" height="660" rx="8"/>
 
   <!-- Title + subtitle -->
   <text class="title" x="450" y="22" text-anchor="middle">qte77 — Authority Chain</text>
   <text class="subtitle" x="450" y="38" text-anchor="middle">Where each decision lives  ·  one source of truth per tier  ·  DRY across the workspace</text>
 
-  <!-- ===== Tier 1: META / POLICY (qte77) ===== -->
+  <!-- ===== Band 1: META · POLICY (qte77) ===== -->
   <rect class="band-bg" x="10" y="54" width="880" height="92" rx="6"/>
-  <text class="tier-label" x="20" y="69">TIER 1  ·  META / POLICY</text>
+  <text class="tier-label" x="20" y="69">META  ·  POLICY</text>
 
   <a xlink:href="https://github.com/qte77/qte77">
     <title>qte77/qte77 — workspace meta: AGENTS.md, project-workflows.md, cross-repo hygiene policy</title>
@@ -56,37 +56,72 @@
     <text class="box-note" x="450" y="127" text-anchor="middle">policy: "what to do and why" — no mechanism</text>
   </a>
 
-  <!-- Arrow from Tier 1 to Tier 2 -->
+  <!-- Arrow META → KERNEL -->
   <line class="arrow" x1="450" y1="146" x2="450" y2="170"/>
 
-  <!-- ===== Tier 2: TOOL / MECHANISM (polyforge) ===== -->
+  <!-- ===== Band 2: KERNEL · PACKAGES (claude-code-plugins) ===== -->
   <rect class="band-bg" x="10" y="172" width="880" height="92" rx="6"/>
-  <text class="tier-label" x="20" y="187">TIER 2  ·  TOOL / MECHANISM</text>
+  <text class="tier-label" x="20" y="187">KERNEL  ·  PACKAGES</text>
 
-  <a xlink:href="https://github.com/qte77/polyforge-orchestrator">
-    <title>polyforge-orchestrator — the tool: flags, cc-parallel.sh, context-hygiene.md, recipes</title>
+  <a xlink:href="https://github.com/qte77/claude-code-plugins">
+    <title>claude-code-plugins — canonical kernel: rules, skills, plugins (the package source consumed by all repos)</title>
     <rect class="box" x="260" y="196" width="380" height="58" rx="5"/>
-    <text class="box-title" x="450" y="215" text-anchor="middle">polyforge-orchestrator</text>
-    <text class="box-desc" x="450" y="231" text-anchor="middle">the tool  ·  cc-parallel.sh  ·  docs/context-hygiene.md</text>
-    <text class="box-note" x="450" y="245" text-anchor="middle">mechanism: flags, recipes, scripts — how to do it</text>
+    <text class="box-title" x="450" y="215" text-anchor="middle">claude-code-plugins</text>
+    <text class="box-desc" x="450" y="231" text-anchor="middle">the kernel  ·  rules  ·  skills  ·  plugins</text>
+    <text class="box-note" x="450" y="245" text-anchor="middle">package source: distributed via marketplace</text>
   </a>
 
-  <!-- Arrow from Tier 2 to Tier 3 -->
+  <!-- Arrow KERNEL → MECHANISM -->
   <line class="arrow" x1="450" y1="264" x2="450" y2="288"/>
 
-  <!-- ===== Tier 3: CONSUMERS (siblings) ===== -->
+  <!-- ===== Band 3: TOOL · MECHANISM (polyforge + office-forge side-by-side) ===== -->
   <rect class="band-bg" x="10" y="290" width="880" height="92" rx="6"/>
-  <text class="tier-label" x="20" y="305">TIER 3  ·  CONSUMERS</text>
+  <text class="tier-label" x="20" y="305">TOOL  ·  MECHANISM</text>
+
+  <a xlink:href="https://github.com/qte77/polyforge-orchestrator">
+    <title>polyforge-orchestrator — DEV mechanism: cc-parallel.sh, context-hygiene.md, recipes</title>
+    <rect class="box" x="80" y="314" width="380" height="58" rx="5"/>
+    <text class="box-title" x="270" y="333" text-anchor="middle">polyforge-orchestrator</text>
+    <text class="box-desc" x="270" y="349" text-anchor="middle">DEV  ·  cc-parallel.sh  ·  recipes</text>
+    <text class="box-note" x="270" y="363" text-anchor="middle">mechanism for dev orchestration</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/office-forge-orchestrator">
+    <title>office-forge-orchestrator — OFFICE mechanism: doc-pipeline-engine, MCP, /loop</title>
+    <rect class="box" x="480" y="314" width="380" height="58" rx="5"/>
+    <text class="box-title" x="670" y="333" text-anchor="middle">office-forge-orchestrator</text>
+    <text class="box-desc" x="670" y="349" text-anchor="middle">OFFICE  ·  doc-pipeline-engine</text>
+    <text class="box-note" x="670" y="363" text-anchor="middle">mechanism for office orchestration</text>
+  </a>
+
+  <!-- Arrow MECHANISM → STATE -->
+  <line class="arrow" x1="450" y1="382" x2="450" y2="406"/>
+
+  <!-- ===== Band 4: STATE · TRACKING ===== -->
+  <rect class="band-bg" x="10" y="408" width="880" height="92" rx="6"/>
+  <text class="tier-label" x="20" y="423">STATE  ·  TRACKING</text>
+
+  <rect class="box" x="160" y="432" width="580" height="58" rx="5"/>
+  <text class="box-title" x="450" y="451" text-anchor="middle">contributions.json  ·  GitHub Issues  ·  TODO.md</text>
+  <text class="box-desc" x="450" y="467" text-anchor="middle">cross-project state  ·  canonical task state  ·  curated backlog</text>
+  <text class="box-note" x="450" y="481" text-anchor="middle">state lives here, not in mechanism — read+written by both layers above and below</text>
+
+  <!-- Arrow STATE → CONSUMERS -->
+  <line class="arrow" x1="450" y1="500" x2="450" y2="524"/>
+
+  <!-- ===== Band 5: CONSUMERS (siblings) ===== -->
+  <rect class="band-bg" x="10" y="526" width="880" height="92" rx="6"/>
+  <text class="tier-label" x="20" y="541">CONSUMERS</text>
 
   <a xlink:href="https://github.com/qte77">
     <title>30+ sibling repos — consume polyforge; inherit workspace policy; stay rules-light</title>
-    <rect class="box" x="160" y="314" width="580" height="58" rx="5"/>
-    <text class="box-title" x="450" y="333" text-anchor="middle">30+ sibling repos</text>
-    <text class="box-desc" x="450" y="349" text-anchor="middle">Agents-eval  ·  ralph-loop  ·  ai-agents-research  ·  paperverse  ·  …</text>
-    <text class="box-note" x="450" y="363" text-anchor="middle">operands: no new hygiene docs  ·  stay rules-light  ·  run under polyforge</text>
+    <rect class="box" x="160" y="550" width="580" height="58" rx="5"/>
+    <text class="box-title" x="450" y="569" text-anchor="middle">30+ sibling repos</text>
+    <text class="box-desc" x="450" y="585" text-anchor="middle">Agents-eval  ·  ralph-loop  ·  ai-agents-research  ·  paperverse  ·  …</text>
+    <text class="box-note" x="450" y="599" text-anchor="middle">operands: no new hygiene docs  ·  stay rules-light  ·  run under polyforge</text>
   </a>
 
   <!-- Footer -->
-  <text class="note" x="20" y="402">policy ≠ mechanism ≠ operand  ·  each concern lives in exactly one tier</text>
-  <text class="note" x="880" y="402" text-anchor="end">DRY across 30+ repos: one AGENTS.md rule  ·  one tool doc  ·  no sibling duplication</text>
+  <text class="note" x="20" y="638">policy ≠ mechanism ≠ operand  ·  each concern lives in exactly one tier</text>
+  <text class="note" x="880" y="638" text-anchor="end">DRY across 30+ repos: one AGENTS.md rule  ·  one tool doc  ·  no sibling duplication</text>
 </svg>

--- a/assets/images/mental-model.svg
+++ b/assets/images/mental-model.svg
@@ -68,10 +68,10 @@
   <rect class="band-bg" x="10" y="116" width="880" height="68" rx="6"/>
   <text class="band-label" x="20" y="131">SPECS</text>
 
-  <a xlink:href="https://github.com/qte77/RAPID-spec-forge">
-    <title>RAPID-spec-forge — BRD → PRD → FRD spec generation</title>
+  <a xlink:href="https://github.com/qte77/qte77/issues/50">
+    <title>spec-forge — BRD → PRD → FRD spec generation</title>
     <rect class="box" x="330" y="136" width="240" height="40" rx="5"/>
-    <text class="box-title" x="450" y="153" text-anchor="middle">RAPID-spec-forge</text>
+    <text class="box-title" x="450" y="153" text-anchor="middle">spec-forge</text>
     <text class="box-desc" x="450" y="167" text-anchor="middle">BRD → PRD → FRD</text>
   </a>
 
@@ -157,7 +157,7 @@
     <title>Infrastructure: dotfiles, cc-plugins, cc-recursive-team, eyerest-theme, diagramforge, polyfetch-scrape</title>
     <rect class="box" x="315" y="590" width="260" height="48" rx="5"/>
     <text class="box-title" x="445" y="609" text-anchor="middle">INFRASTRUCTURE  ·  6 repos</text>
-    <text class="box-desc" x="445" y="624" text-anchor="middle">dotfiles  ·  cc-plugins  ·  diagramforge  ·  …</text>
+    <text class="box-desc" x="445" y="624" text-anchor="middle">dotfiles  ·  claude-code-plugins  ·  diagramforge  ·  …</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/agenthud-agui-a2ui">

--- a/assets/images/pipeline-layers.svg
+++ b/assets/images/pipeline-layers.svg
@@ -147,29 +147,15 @@
     <text class="repo-desc" x="580" y="386" text-anchor="middle">contribution graph art</text>
   </a>
 
-  <!-- ===== Layer 5: IMPLEMENT (3 boxes) ===== -->
+  <!-- ===== Layer 5: IMPLEMENT (single generic consumer box) ===== -->
   <rect class="layer-bg" x="10" y="408" width="840" height="66" rx="6"/>
   <text class="layer-label" x="20" y="422">IMPLEMENT — act on it</text>
 
-  <a xlink:href="https://github.com/qte77/learnings-ralphy">
-    <title>learnings-ralphy — distills LEARNINGS patterns into TDD improvements (Thu)</title>
-    <rect class="box" x="50" y="428" width="230" height="38" rx="5"/>
-    <text class="repo-name" x="165" y="444" text-anchor="middle">learnings-ralphy</text>
-    <text class="repo-desc" x="165" y="458" text-anchor="middle">patterns → TDD improvements (Thu)</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/research-ralphy">
-    <title>research-ralphy — turns discoveries into TDD implementations (Wed)</title>
-    <rect class="box" x="315" y="428" width="230" height="38" rx="5"/>
-    <text class="repo-name" x="430" y="444" text-anchor="middle">research-ralphy</text>
-    <text class="repo-desc" x="430" y="458" text-anchor="middle">discoveries → implementations (Wed)</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/ralph-loop-cc-tdd-wt-vibe-kanban-template">
-    <title>ralph self-improve — digests offspring learnings, improves loop engine (Fri)</title>
-    <rect class="box" x="580" y="428" width="230" height="38" rx="5"/>
-    <text class="repo-name" x="695" y="444" text-anchor="middle">ralph self-improve</text>
-    <text class="repo-desc" x="695" y="458" text-anchor="middle">loop engine evolution (Fri)</text>
+  <a xlink:href="https://github.com/qte77">
+    <title>consumer repos — sibling projects that run these GHAs and act on their outputs</title>
+    <rect class="box" x="160" y="428" width="540" height="38" rx="5"/>
+    <text class="repo-name" x="430" y="444" text-anchor="middle">consumer repos</text>
+    <text class="repo-desc" x="430" y="458" text-anchor="middle">Agents-eval  ·  paperverse  ·  ralphy offspring  ·  …</text>
   </a>
 
   <!-- ===== Downward arrows between layers ===== -->

--- a/assets/images/pipeline-layers.svg
+++ b/assets/images/pipeline-layers.svg
@@ -186,6 +186,6 @@
   <text class="note" x="445" y="127">index.json</text>
 
   <!-- Footer -->
-  <text class="note" x="20" y="502">12 GitHub Actions + 3 consumers</text>
+  <text class="note" x="20" y="502">GitHub Actions + consumers</text>
   <text class="note" x="840" y="502" text-anchor="end">feedback: learnings flow back to registry via compound writeback</text>
 </svg>

--- a/assets/images/pipeline-layers.svg
+++ b/assets/images/pipeline-layers.svg
@@ -54,36 +54,29 @@
     <text class="repo-desc" x="430" y="98" text-anchor="middle">registry/index.json → SOT for all layers</text>
   </a>
 
-  <!-- ===== Layer 1: OBSERVE (4 boxes) ===== -->
+  <!-- ===== Layer 1: OBSERVE (3 boxes) ===== -->
   <rect class="layer-bg" x="10" y="120" width="840" height="66" rx="6"/>
   <text class="layer-label" x="20" y="134">OBSERVE — what happens</text>
 
   <a xlink:href="https://github.com/qte77/gha-arbitrary-repo-timeline">
     <title>gha-arbitrary-repo-timeline — issues, PRs, commits per repo over time</title>
-    <rect class="box" x="20" y="140" width="195" height="38" rx="5"/>
-    <text class="repo-name" x="117" y="156" text-anchor="middle">repo-timeline</text>
-    <text class="repo-desc" x="117" y="170" text-anchor="middle">issues/PRs/commits over time</text>
+    <rect class="box" x="123" y="140" width="195" height="38" rx="5"/>
+    <text class="repo-name" x="220" y="156" text-anchor="middle">repo-timeline</text>
+    <text class="repo-desc" x="220" y="170" text-anchor="middle">issues/PRs/commits over time</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-arxiv-stats-action">
     <title>gha-arxiv-stats-action — daily arXiv paper stats by category</title>
-    <rect class="box" x="230" y="140" width="195" height="38" rx="5"/>
-    <text class="repo-name" x="327" y="156" text-anchor="middle">arxiv-stats</text>
-    <text class="repo-desc" x="327" y="170" text-anchor="middle">daily arXiv paper stats</text>
+    <rect class="box" x="333" y="140" width="195" height="38" rx="5"/>
+    <text class="repo-name" x="430" y="156" text-anchor="middle">arxiv-stats</text>
+    <text class="repo-desc" x="430" y="170" text-anchor="middle">daily arXiv paper stats</text>
   </a>
 
   <a xlink:href="https://github.com/qte77/gha-biorxiv-stats-action">
     <title>gha-biorxiv-stats-action — daily bioRxiv paper stats by category</title>
-    <rect class="box" x="440" y="140" width="195" height="38" rx="5"/>
-    <text class="repo-name" x="537" y="156" text-anchor="middle">biorxiv-stats</text>
-    <text class="repo-desc" x="537" y="170" text-anchor="middle">daily bioRxiv paper stats</text>
-  </a>
-
-  <a xlink:href="https://github.com/qte77/parse-git-log-action">
-    <title>parse-git-log-action — parse git log into structured events</title>
-    <rect class="box" x="650" y="140" width="195" height="38" rx="5"/>
-    <text class="repo-name" x="747" y="156" text-anchor="middle">parse-git-log</text>
-    <text class="repo-desc" x="747" y="170" text-anchor="middle">git log → structured events</text>
+    <rect class="box" x="543" y="140" width="195" height="38" rx="5"/>
+    <text class="repo-name" x="640" y="156" text-anchor="middle">biorxiv-stats</text>
+    <text class="repo-desc" x="640" y="170" text-anchor="middle">daily bioRxiv paper stats</text>
   </a>
 
   <!-- ===== Layer 2: TRANSFORM (4 boxes) ===== -->
@@ -193,6 +186,6 @@
   <text class="note" x="445" y="127">index.json</text>
 
   <!-- Footer -->
-  <text class="note" x="20" y="502">13 GitHub Actions + 3 consumers</text>
+  <text class="note" x="20" y="502">12 GitHub Actions + 3 consumers</text>
   <text class="note" x="840" y="502" text-anchor="end">feedback: learnings flow back to registry via compound writeback</text>
 </svg>


### PR DESCRIPTION
## Summary

Five topical commits, each one concern:

1. **`docs(mental-model)`** — SPECS box retargeted to `spec-forge` plugin (link → qte77/qte77#50); INFRASTRUCTURE description uses canonical `claude-code-plugins` name.
2. **`docs(authority-chain)`** — restructured 3 → 5 tiers: adds KERNEL · PACKAGES (claude-code-plugins) between META and MECHANISM; splits MECHANISM into polyforge (DEV) + office-forge (OFFICE) side-by-side; adds STATE · TRACKING tier (contributions.json + GitHub Issues + TODO.md). Drops "TIER N" prefixes. viewBox 420 → 660.
3. **`docs(readme)` wordmark** — `width="100%"` so the centered wrapper places the wordmark correctly on GitHub.
4. **`docs(readme)` diagrams** — swap GHA pipeline for authority-chain in the architecture slot; add why-framing under Mental Model and Authority Chain headings; pipeline-layers retained as a link below.
5. **`docs(readme)` hero** — rewrite to lead with the outcome (turn goals into merged PRs); drop stale tool names ("RAPID") and the redundant blockquote restatement.

`pipeline-layers.svg` untouched (confirmed current; no drift).

## Test plan
- [ ] mental-model.svg: SPECS box reads "spec-forge" and clicks through to qte77/qte77#50
- [ ] mental-model.svg: INFRASTRUCTURE description shows `claude-code-plugins`
- [ ] authority-chain.svg: 5 bands visible, no overlap, in order META → KERNEL → MECHANISM → STATE → CONSUMERS
- [ ] authority-chain.svg: KERNEL band shows `claude-code-plugins` with link
- [ ] authority-chain.svg: MECHANISM band shows polyforge and office-forge side-by-side
- [ ] authority-chain.svg: STATE band shows contributions.json + GitHub Issues + TODO.md
- [ ] authority-chain.svg: tier labels read without "TIER N" prefixes
- [ ] Both SVGs render correctly in GitHub dark mode
- [ ] README hero leads with outcome, no stale "RAPID" reference
- [ ] README architecture section shows authority-chain (not pipeline-layers); pipeline link present
- [ ] README wordmark renders centered