### PR TITLE
docs(readme): clarify hero, add roadmap, trim lineage dup

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Policy, mechanism, and state get confused and duplicated across repos. Naming wh
 
 Each repo carries its own quickstart.
 
+## Roadmap
+
+- **Now** — GitHub-native (Actions, Issues, PRs); Claude Code agents.
+- **Next** — spec-forge methodology landing in [claude-code-plugins](https://github.com/qte77/claude-code-plugins).
+- **Later** — runtime portability: air-gapped, BYOM, your stack.
+
 ## Profile
 
 ### Topics

--- a/README.md
+++ b/README.md
@@ -8,11 +8,7 @@
   </picture>
 </p>
 
-Turn goals into merged PRs across many repos. Agents drive the loop; humans can approve and steer; engines do the heavy lifting.
-
-qte77 is a GitHub account hosting a runtime-portable framework. Today: GitHub (Actions, Issues, PRs). Tomorrow: anywhere — air-gapped, BYOM, your stack.
-
-> Without coordination, agentic work across many repos drifts — learnings get lost, work duplicates, goals lose their thread. qte77 keeps the goal → spec → build → learn loop compounding, not forgetting.
+**qte77** hosts a framework for compounding agentic work — keeping goals, specs, builds, and learnings in one feedback loop instead of drifting. Agents drive it; humans approve and steer. Proof: 30+ repos running on it here.
 
 ## Mental Model
 

--- a/README.md
+++ b/README.md
@@ -114,4 +114,4 @@ Each repo carries its own quickstart.
 
 How the current system got here — proof of work, not required reading.
 
-The spec-generation work started in [`context-engineering-template-legacy`](https://github.com/qte77/context-engineering-template-legacy) (2025-07-06), where the BRD → PRD → FRD pipeline first took shape. [`RAPID-spec-forge-legacy`](https://github.com/qte77/RAPID-spec-forge-legacy) carried it forward until archived (2026-04-26). The methodology is now landing in [`claude-code-plugins`](https://github.com/qte77/claude-code-plugins) as the `spec-forge` plugin.
+The spec-generation work started in [`context-engineering-template-legacy`](https://github.com/qte77/context-engineering-template-legacy) (2025-07-06), where the BRD → PRD → FRD pipeline first took shape. [`RAPID-spec-forge-legacy`](https://github.com/qte77/RAPID-spec-forge-legacy) carried it forward until archived (2026-04-26).


### PR DESCRIPTION
## Summary

- **Hero** — collapse three stacked pitches (action / identity / problem blockquote) into one sentence; framework is the actor, qte77 is the host, 30+ repos as proof. Drops PR-specific framing so the hero matches the body's broader scope.
- **Roadmap** — new section between Get started and Profile, naming three time horizons (Now / Next / Later). Aspirational claims (air-gapped, BYOM) move out of the hero into where they read as roadmap rather than overselling.
- **Lineage** — drop the spec-forge "now landing" sentence; Roadmap's Next line covers it. Lineage stays purely historical.

## Test plan

- [ ] CI passes (markdown lint)
- [ ] Hero reads cleanly on rendered GitHub view
- [ ] Roadmap section renders between Get started and Profile
- [ ] No duplicate spec-forge mention between Roadmap and Lineage

Generated with Claude <noreply@anthropic.com>