### PR TITLE
docs(diagrams): humans-in-the-loop in mental-model + authority-chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@
   </picture>
 </p>
 
+<p align="center">
+  <a href="https://github.com/qte77/qte77/commits/main"><img src="https://img.shields.io/github/last-commit/qte77/qte77?label=last%20commit" alt="Last commit"></a>
+  <a href="https://github.com/qte77/qte77/issues"><img src="https://img.shields.io/github/issues/qte77/qte77?label=open%20issues" alt="Open issues"></a>
+</p>
+
 **qte77** hosts a framework for compounding agentic work — keeping goals, specs, builds, and learnings in one feedback loop instead of drifting. Agents drive it; humans approve and steer. Proof: 30+ repos running on it here.
 
 ## Mental Model

--- a/README.md
+++ b/README.md
@@ -8,11 +8,6 @@
   </picture>
 </p>
 
-<p align="center">
-  <a href="https://github.com/qte77/qte77/commits/main"><img src="https://img.shields.io/github/last-commit/qte77/qte77?label=last%20commit" alt="Last commit"></a>
-  <a href="https://github.com/qte77/qte77/issues"><img src="https://img.shields.io/github/issues/qte77/qte77?label=open%20issues" alt="Open issues"></a>
-</p>
-
 **qte77** hosts a framework for compounding agentic work — keeping goals, specs, builds, and learnings in one feedback loop instead of drifting. Agents drive it; humans approve and steer. Proof: 30+ repos running on it here.
 
 ## Mental Model

--- a/assets/images/authority-chain.svg
+++ b/assets/images/authority-chain.svg
@@ -44,16 +44,16 @@
   <text class="title" x="450" y="22" text-anchor="middle">qte77 — Authority Chain</text>
   <text class="subtitle" x="450" y="38" text-anchor="middle">Where each decision lives  ·  one source of truth per tier  ·  DRY across the workspace</text>
 
-  <!-- ===== Band 1: META · POLICY (qte77) ===== -->
+  <!-- ===== Band 1: META · POLICY · HUMANS DECIDE (qte77) ===== -->
   <rect class="band-bg" x="10" y="54" width="880" height="92" rx="6"/>
-  <text class="tier-label" x="20" y="69">META  ·  POLICY</text>
+  <text class="tier-label" x="20" y="69">META  ·  POLICY  ·  HUMANS DECIDE</text>
 
   <a xlink:href="https://github.com/qte77/qte77">
-    <title>qte77/qte77 — workspace meta: AGENTS.md, project-workflows.md, cross-repo hygiene policy</title>
+    <title>qte77/qte77 — workspace meta: AGENTS.md, project-workflows.md, cross-repo hygiene policy. Humans are the policy authority; this repo records their decisions.</title>
     <rect class="box" x="260" y="78" width="380" height="58" rx="5"/>
     <text class="box-title" x="450" y="97" text-anchor="middle">qte77/qte77</text>
     <text class="box-desc" x="450" y="113" text-anchor="middle">workspace meta  ·  AGENTS.md  ·  project-workflows.md</text>
-    <text class="box-note" x="450" y="127" text-anchor="middle">policy: "what to do and why" — no mechanism</text>
+    <text class="box-note" x="450" y="127" text-anchor="middle">humans set policy  ·  this repo records it  ·  no mechanism</text>
   </a>
 
   <!-- Arrow META → KERNEL -->

--- a/assets/images/mental-model.svg
+++ b/assets/images/mental-model.svg
@@ -54,15 +54,21 @@
   <text class="title" x="450" y="22" text-anchor="middle">qte77 — Mental Model</text>
   <text class="subtitle" x="450" y="38" text-anchor="middle">Goals flow down  ·  learnings flow back  ·  support band underneath</text>
 
-  <!-- ===== NORTH STAR (dashed) ===== -->
+  <!-- ===== HUMANS (left) + NORTH STAR (right, dashed) — both feed SPECS ===== -->
+  <rect class="box" x="130" y="54" width="220" height="38" rx="5"/>
+  <text class="box-title" x="240" y="70" text-anchor="middle">HUMANS</text>
+  <text class="box-desc" x="240" y="84" text-anchor="middle">approve  ·  review PRs  ·  steer</text>
+
   <a xlink:href="https://github.com/qte77/liminal-flux-gh-acc">
     <title>liminal-flux — self-evolving agent-operated GitHub account</title>
-    <rect class="box-star" x="340" y="54" width="220" height="38" rx="5"/>
-    <text class="box-title" x="450" y="70" text-anchor="middle">NORTH STAR</text>
-    <text class="box-desc" x="450" y="84" text-anchor="middle">liminal-flux  ·  agent-operated account</text>
+    <rect class="box-star" x="550" y="54" width="220" height="38" rx="5"/>
+    <text class="box-title" x="660" y="70" text-anchor="middle">NORTH STAR</text>
+    <text class="box-desc" x="660" y="84" text-anchor="middle">liminal-flux  ·  agent-operated account</text>
   </a>
 
-  <line class="arrow" x1="450" y1="92" x2="450" y2="116"/>
+  <!-- Both top boxes converge at a junction, then a single arrow into SPECS -->
+  <path class="arrow" d="M 240,92 L 240,104 L 450,104 L 450,116"/>
+  <path class="arrow" d="M 660,92 L 660,104 L 450,104 L 450,116"/>
 
   <!-- ===== SPECS (single item — no section-name repetition) ===== -->
   <rect class="band-bg" x="10" y="116" width="880" height="68" rx="6"/>

--- a/assets/images/mental-model.svg
+++ b/assets/images/mental-model.svg
@@ -57,7 +57,7 @@
   <!-- ===== HUMANS (left) + NORTH STAR (right, dashed) — both feed SPECS ===== -->
   <rect class="box" x="130" y="54" width="220" height="38" rx="5"/>
   <text class="box-title" x="240" y="70" text-anchor="middle">HUMANS</text>
-  <text class="box-desc" x="240" y="84" text-anchor="middle">approve  ·  review PRs  ·  steer</text>
+  <text class="box-desc" x="240" y="84" text-anchor="middle">set goals  ·  track OKRs  ·  HITL optional</text>
 
   <a xlink:href="https://github.com/qte77/liminal-flux-gh-acc">
     <title>liminal-flux — self-evolving agent-operated GitHub account</title>


### PR DESCRIPTION
## Summary

Surfaces human-in-the-loop framing in the two governance diagrams introduced after PR #66's README reframing.

- `mental-model.svg` — adds HUMANS box paired with NORTH STAR (both feed SPECS via converging arrows). Description: \`set goals  ·  track OKRs  ·  HITL optional\` — humans canonically set goals and track OKRs; PR-approval / steering is opt-in.
- `authority-chain.svg` — META tier label includes "HUMANS DECIDE"; box-note clarifies "humans set policy · this repo records it · no mechanism".

Initial commit on this branch added status badges; reverted per workspace direction (no badges in profile README).

## Closes

- Closes #68 (humans-in-loop diagrams)

## Not addressed

- **#69 (status badges)** — removed from this PR per workspace direction. Closing #69 separately as won't-fix.
- **#67 (real outcome metrics)** — needs evidence I can't fabricate. Stays open.

## Test plan

- [ ] Render `mental-model.svg` light + dark — HUMANS box paired with NORTH STAR, both feed SPECS
- [ ] Render `authority-chain.svg` light + dark — META tier reads "META · POLICY · HUMANS DECIDE"
- [ ] README has no badge block (only wordmark + tagline at top)

Generated with Claude <noreply@anthropic.com>