### PR TITLE
docs: resolve STATE tier authority — declare ontology, fix SVG, add goals.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,34 @@ GitHub Issues are the source of truth for persistent state.
 If an AR entry persists beyond a few sessions, file it as an Issue and
 remove the AR entry.
 
+## Task-tracking authority
+
+Workspace state lives across four artifacts with distinct, non-overlapping
+scopes. The canonical entity model is
+[`polyforge-orchestrator/config/ontology.json`][ontology] — this section
+quotes it; do not redefine the model here.
+
+| Artifact | Scope | Writers |
+| -------- | ----- | ------- |
+| **GitHub Issues** | Canonical task SOT (per `ontology.json`: `entity: issue`, `persisted: true`) | human, agent, GHA |
+| **[`contributions.json`][contrib]** | Polyforge cross-repo plan execution state — `--resume` source, survives container rebuilds | machine-written by `cc-parallel.sh` |
+| **[`.github-private-project-tracker`][tracker]** | Per-repo tactical issue mirror; bidirectional sync via [`gha-cross-repo-issue-sync`][sync] (close/reopen/labels propagate) | tracker GHA + maintainers |
+| **`goals.json`** (this repo) | Workspace OKRs / strategic goals | humans only |
+
+**Rule:** GitHub Issues are the SOT for tasks. `contributions.json` and
+the tracker are derived state — never write tasks to them without a
+corresponding Issue. `goals.json` is meta to all of these (it describes
+*why* tasks exist, not which tasks).
+
+**DRY:** the entity definitions, storage, and writer/reader matrix live
+in `ontology.json`. Link out, do not duplicate. If the model changes,
+update the ontology in polyforge — this section reflects it.
+
+[ontology]: https://github.com/qte77/polyforge-orchestrator/blob/main/config/ontology.json
+[contrib]: https://github.com/qte77/polyforge-orchestrator/blob/main/config/contributions.json
+[tracker]: https://github.com/qte77/.github-private-project-tracker
+[sync]: https://github.com/qte77/gha-cross-repo-issue-sync
+
 ## Cross-repo agent hygiene
 
 Workspace-level policy for agents operating across multiple repos. Mechanism

--- a/assets/images/authority-chain.svg
+++ b/assets/images/authority-chain.svg
@@ -101,10 +101,37 @@
   <rect class="band-bg" x="10" y="408" width="880" height="92" rx="6"/>
   <text class="tier-label" x="20" y="423">STATE  ·  TRACKING</text>
 
-  <rect class="box" x="160" y="432" width="580" height="58" rx="5"/>
-  <text class="box-title" x="450" y="451" text-anchor="middle">contributions.json  ·  GitHub Issues  ·  TODO.md</text>
-  <text class="box-desc" x="450" y="467" text-anchor="middle">cross-project state  ·  canonical task state  ·  curated backlog</text>
-  <text class="box-note" x="450" y="481" text-anchor="middle">state lives here, not in mechanism — read+written by both layers above and below</text>
+  <a xlink:href="https://github.com/qte77/qte77/issues">
+    <title>GitHub Issues — canonical task SOT (per polyforge ontology.json)</title>
+    <rect class="box" x="40" y="432" width="200" height="58" rx="5"/>
+    <text class="box-title" x="140" y="451" text-anchor="middle">GitHub Issues</text>
+    <text class="box-desc" x="140" y="467" text-anchor="middle">canonical task SOT</text>
+    <text class="box-note" x="140" y="481" text-anchor="middle">human + agent + GHA writers</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/polyforge-orchestrator/blob/main/config/contributions.json">
+    <title>contributions.json — polyforge cross-repo plan execution state (machine-written, --resume source)</title>
+    <rect class="box" x="250" y="432" width="200" height="58" rx="5"/>
+    <text class="box-title" x="350" y="451" text-anchor="middle">contributions.json</text>
+    <text class="box-desc" x="350" y="467" text-anchor="middle">polyforge execution state</text>
+    <text class="box-note" x="350" y="481" text-anchor="middle">cross-repo plan; survives rebuilds</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/polyforge-orchestrator/blob/main/config/ontology.json">
+    <title>ontology.json — entity model (12 types, 11 typed relationships) — defines storage/writers/readers</title>
+    <rect class="box" x="460" y="432" width="200" height="58" rx="5"/>
+    <text class="box-title" x="560" y="451" text-anchor="middle">ontology.json</text>
+    <text class="box-desc" x="560" y="467" text-anchor="middle">entity model</text>
+    <text class="box-note" x="560" y="481" text-anchor="middle">defines this very tier</text>
+  </a>
+
+  <a xlink:href="https://github.com/qte77/qte77/blob/main/goals.json">
+    <title>goals.json — workspace OKRs / strategic goals (humans write; orchestrators read)</title>
+    <rect class="box" x="670" y="432" width="200" height="58" rx="5"/>
+    <text class="box-title" x="770" y="451" text-anchor="middle">goals.json</text>
+    <text class="box-desc" x="770" y="467" text-anchor="middle">workspace OKRs</text>
+    <text class="box-note" x="770" y="481" text-anchor="middle">humans set; agents read</text>
+  </a>
 
   <!-- Arrow STATE → CONSUMERS -->
   <line class="arrow" x1="450" y1="500" x2="450" y2="524"/>

--- a/docs/project-workflows.md
+++ b/docs/project-workflows.md
@@ -24,7 +24,7 @@ Orchestrator (polyforge)
 - Single session with `additionalDirectories` = only main repo's context loads
 - Subagents inherit parent's context, not the target repo's
 
-**Bridges across sessions:**
+**Bridges across sessions (CC session-to-session state):**
 
 | Bridge | Direction | What it carries |
 | ------ | --------- | --------------- |
@@ -33,6 +33,17 @@ Orchestrator (polyforge)
 | Compound learnings | Agent ↔ agent | Shared patterns via ai-agents-research/docs/learnings/ |
 | CC plans | Session → session | Decisions persist at ~/.claude/plans/, loaded on next session |
 | CC memory | Session → session | Per-project MEMORY.md, auto-loaded on conversation start |
+
+**Cross-repo task state (workspace persistence):**
+
+See [`AGENTS.md` § Task-tracking authority](../AGENTS.md#task-tracking-authority) for the full four-artifact model and writer policy. Quick reference:
+
+| Bridge | Direction | What it carries |
+| ------ | --------- | --------------- |
+| GitHub Issues | Human ↔ agent ↔ GHA | Canonical task SOT (per polyforge `ontology.json`) |
+| `contributions.json` | Polyforge → polyforge | Cross-repo plan execution; survives container rebuilds |
+| Private tracker | Repos ↔ tracker (bidir) | Per-repo tactical mirror; close/reopen/labels propagate via `gha-cross-repo-issue-sync` |
+| `goals.json` | Humans → orchestrators | Workspace OKRs / strategic goals (this repo's root) |
 
 **Design implications:**
 

--- a/goals.json
+++ b/goals.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "version": "0.1.0",
+  "updated": "2026-04-25",
+  "scope": "qte77 workspace OKRs / strategic goals — humans set these; orchestrators read them. Schema intentionally minimal until first cockpit/dashboard consumer pressure-tests it (see qte77/qte77#67).",
+  "goals": []
+}


### PR DESCRIPTION
## Summary

Resolves the coupled pair #41 (Ontology + STATE tier direction) and #54 (FIXME: task-tracking authority). Phase-1 exploration revealed the design is ~90% done in polyforge — `contributions.json` v1.0.0 and `ontology.json` v1.0.0 with full JSON Schemas already exist there. This PR declares them in qte77/qte77 governance (the META tier) and fixes the diagrams.

## Changes (4 commits)

1. **`feat: add goals.json`** — minimal workspace-OKR scaffold at the repo root. Schema intentionally underspecified until the first cockpit/dashboard consumer (#67) pressure-tests it.
2. **`docs(svg): authority-chain STATE tier`** — replace fictional `TODO.md` reference with four real artifacts (GitHub Issues, contributions.json, ontology.json, goals.json), each clickable to its live source.
3. **`docs(agents): declare task-tracking authority`** — new section in AGENTS.md naming the four-artifact state model with non-overlapping scopes. Quotes polyforge `ontology.json` rather than redefining (DRY). Slots between the AR-vs-Issue policy and cross-repo hygiene.
4. **`docs(workflows): extend bridges with cross-repo task state`** — add a sub-section to the bridges table for workspace-persistent state, paired with the existing CC session-to-session sub-section.

## Key decisions (per user input)

- **`goals.json` lives at qte77/qte77 root** — workspace OKRs are META-tier; humans set, orchestrators read.
- **Private tracker is legitimate, not deprecated** — handles tactical per-repo mirror scope, distinct from `contributions.json`'s cross-repo plan execution scope. Three state artifacts coexist with non-overlapping scopes.
- **SVG references real artifacts** — clickable `<a xlink:href>` to the live JSON files (works in direct SVG view; GitHub strips in README).

## DRY enforcement

- Entity model lives in polyforge `ontology.json`; AGENTS.md links to it, doesn't redefine.
- AGENTS.md is the authoritative declaration; project-workflows.md links back to it for the cross-repo task state table.

## Out of scope

- **Workspace-level `AGENTS.md` fix** (out-of-repo): the upstream workspace AGENTS.md erroneously says the private tracker is deprecated. This needs a separate one-line fix in whichever process owns that file. Flagged in the plan but not in this PR.
- No schema design for `goals.json` beyond the version/scope/empty-array scaffold.
- No migration of tracker contents to GitHub Issues — different scopes, both legitimate.
- No changes to polyforge schemas — they're already correct.

## Closes / refs

- Closes #41
- Closes #54
- Refs #67 (real metrics — `goals.json` provides a future home)

## Test plan

- [ ] Render authority-chain.svg in light + dark mode — STATE tier shows 4 boxes, no `TODO.md`
- [ ] Open SVG directly (not via README) — clicking each STATE box navigates to live artifact
- [ ] `jq . goals.json` parses successfully
- [ ] AGENTS.md task-tracking section renders, all 4 markdown reference links resolve
- [ ] project-workflows.md bridges table now has 2 labeled sub-sections (5 + 4 rows)

Generated with Claude <noreply@anthropic.com>