### PR TITLE
docs(readme): move Lineage section after Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Each repo carries its own quickstart.
 - **Next** — spec-forge methodology landing in [claude-code-plugins](https://github.com/qte77/claude-code-plugins).
 - **Later** — runtime portability: air-gapped, BYOM, your stack.
 
+## Lineage
+
+How the current system got here — proof of work, not required reading.
+
+The spec-generation work started in [`context-engineering-template-legacy`](https://github.com/qte77/context-engineering-template-legacy) (2025-07-06), where the BRD → PRD → FRD pipeline first took shape. [`RAPID-spec-forge-legacy`](https://github.com/qte77/RAPID-spec-forge-legacy) carried it forward until archived (2026-04-26).
+
 ## Profile
 
 ### Topics
@@ -109,9 +115,3 @@ Each repo carries its own quickstart.
 - [x] Kaggle Competitions
 - [ ] Codewars Python
 - [ ] Advent of Code
-
-## Lineage
-
-How the current system got here — proof of work, not required reading.
-
-The spec-generation work started in [`context-engineering-template-legacy`](https://github.com/qte77/context-engineering-template-legacy) (2025-07-06), where the BRD → PRD → FRD pipeline first took shape. [`RAPID-spec-forge-legacy`](https://github.com/qte77/RAPID-spec-forge-legacy) carried it forward until archived (2026-04-26).


### PR DESCRIPTION
## Summary

Pure reorder. Lineage section (project history) was at the very end after TODO, reading as a stray footnote. Move it to sit after Roadmap and before Profile, so the reading flow is forward-looking → backward-looking → meta:

```
Mental Model
  → Get started
  → Roadmap        (forward)
  → Lineage        (backward — moved here)
  → Profile        (Topics · Interests · Posts · Tools · TODO)
```

No content changes.

## Test plan

- [ ] Render README — Lineage appears between Roadmap and Profile
- [ ] No duplicated Lineage sections, no broken anchor links

Generated with Claude <noreply@anthropic.com>