### PR TITLE
fix(plugins): correct marketplace name to qte77-claude-code-utils

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,12 +4,12 @@
     "pr": "Generated with Claude <noreply@anthropic.com>"
   },
   "enabledPlugins": {
-    "commit-helper@qte77-claude-code-plugins": true,
-    "workspace-setup@qte77-claude-code-plugins": true,
-    "docs-governance@qte77-claude-code-plugins": true
+    "commit-helper@qte77-claude-code-utils": true,
+    "workspace-setup@qte77-claude-code-utils": true,
+    "docs-governance@qte77-claude-code-utils": true
   },
   "extraKnownMarketplaces": {
-    "qte77-claude-code-plugins": {
+    "qte77-claude-code-utils": {
       "source": {
         "source": "github",
         "repo": "qte77/claude-code-plugins"


### PR DESCRIPTION
## Summary
- Rename marketplace key `qte77-claude-code-plugins` → `qte77-claude-code-utils` in `.claude/settings.json`
- Aligns with marketplace self-identifier at `qte77/claude-code-plugins`; `source.repo` unchanged

## Why
The marketplace at `qte77/claude-code-plugins` self-identifies as `qte77-claude-code-utils`. The mismatched key caused `/reload-plugins` to fail with `Plugin not found in marketplace` for every entry.

## Test plan
- [ ] `/reload-plugins` reports 0 errors
- [ ] `/doctor` shows no marketplace mismatches

Mirrors qte77/polyforge-orchestrator#60.

Generated with Claude <noreply@anthropic.com>