### PR TITLE
docs(readme): group GitHub Models with Hugging Face (AI-models cluster)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ The spec-generation work started in [`context-engineering-template-legacy`](http
   --><img src="https://github.com/devicons/devicon/blob/master/icons/bash/bash-original.svg" title="Bash" alt="Bash" width="32" height="32"/><!--
   --><picture><source media="(prefers-color-scheme: dark)" srcset="https://github.com/devicons/devicon/blob/master/icons/git/git-plain.svg"><img src="https://github.com/devicons/devicon/blob/master/icons/git/git-original.svg" title="Git" alt="Git" width="32" height="32"/></picture><!--
   --><img src="https://github.com/devicons/devicon/blob/master/icons/githubactions/githubactions-original.svg" title="GitHub Actions" alt="GitHub Actions" width="32" height="32"/><!--
-  --><picture><source media="(prefers-color-scheme: dark)" srcset="assets/images/icons/gh-models-dark.svg"><img src="assets/images/icons/gh-models-light.svg" title="GitHub Models" alt="GitHub Models" width="32" height="32"/></picture><!--
   --><img src="https://github.com/devicons/devicon/blob/master/icons/docker/docker-original.svg" title="Docker" alt="Docker" width="32" height="32"/><!--
   --><picture><source media="(prefers-color-scheme: dark)" srcset="assets/images/icons/devcontainers-dark.svg"><img src="assets/images/icons/devcontainers-light.svg" title="Dev Containers" alt="Dev Containers" width="32" height="32"/></picture><!--
   --><picture><source media="(prefers-color-scheme: dark)" srcset="https://github.com/devicons/devicon/blob/master/icons/azure/azure-original.svg"><img src="https://github.com/devicons/devicon/blob/master/icons/azure/azure-plain.svg" title="Azure" alt="Azure" width="32" height="32"/></picture><!--
@@ -106,6 +105,7 @@ The spec-generation work started in [`context-engineering-template-legacy`](http
   --><img src="https://github.com/devicons/devicon/blob/master/icons/googlecloud/googlecloud-plain.svg" title="Google Cloud" alt="Google Cloud" width="32" height="32"/><!--
   --><picture><source media="(prefers-color-scheme: dark)" srcset="assets/images/icons/ros-dark.svg"><img src="assets/images/icons/ros-light.svg" title="ROS" alt="ROS" width="32" height="32"/></picture><!--
   --><img src="assets/images/icons/huggingface.svg" title="Hugging Face" alt="Hugging Face" width="32" height="32"/><!--
+  --><picture><source media="(prefers-color-scheme: dark)" srcset="assets/images/icons/gh-models-dark.svg"><img src="assets/images/icons/gh-models-light.svg" title="GitHub Models" alt="GitHub Models" width="32" height="32"/></picture><!--
   --><img src="assets/images/icons/claude.svg" title="Claude" alt="Claude" width="32" height="32"/><!--
 --></div>
 


### PR DESCRIPTION
## Summary

Pure reorder. Move the GitHub Models picture block out of the GitHub-platform cluster (between GitHub Actions and Docker) and into the AI-models cluster (between Hugging Face and Claude).

**Before:**
\`... · GitHub Actions · GitHub Models · Docker · Dev Containers · ... · ROS · Hugging Face · Claude\`

**After:**
\`... · GitHub Actions · Docker · Dev Containers · ... · ROS · Hugging Face · GitHub Models · Claude\`

Reading flow: HF (broad open hub) → GHM (curated GitHub-flavored aggregator) → Claude (the agent consuming both).

No file additions, no SVG changes — just reorder.

## Test plan

- [ ] Render README — GitHub Models now sits between Hugging Face and Claude
- [ ] All icons render in light + dark mode (no regression)
- [ ] No row wrap

Generated with Claude <noreply@anthropic.com>