### PR TITLE
docs(readme): add Authority Chain in-prose legend (#72)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Read it as: goals at the top feed specs, specs feed builds, builds emit learning
 
 Policy, mechanism, and state get confused and duplicated across repos. Naming where each decision lives prevents the drift and keeps 30+ repos DRY.
 
+- **META** — policy (what we optimize for)
+- **KERNEL** — invariants (rules that must hold)
+- **MECHANISM** — code (how rules are enforced)
+- **STATE** — data (goals, specs, learnings)
+- **CONSUMERS** — repos (where it lands)
+
 <details>
   <summary>Diagram: META, KERNEL, MECHANISM, STATE, CONSUMERS</summary>
   <img src="assets/images/authority-chain.svg" alt="qte77 Authority Chain — META, KERNEL, MECHANISM, STATE, CONSUMERS" width="100%" />


### PR DESCRIPTION
## Summary

- Add 5-bullet legend (META/KERNEL/MECHANISM/STATE/CONSUMERS) before the collapsed diagram
- Reader who skips images now gets tier semantics inline; reader who opens the diagram gets the same structure visually
- Diagram stays collapsed — demote was already in effect, this resolves the remaining hollow-content concern

## Test plan

- [ ] README renders cleanly; bullets appear before `<details>`
- [ ] Existing diagrams still expand correctly
- [ ] CodeFactor passes

Closes #72.

Generated with Claude <noreply@anthropic.com>