### PR TITLE
docs(readme): substantiate proof claim with linked repos and agent PRs (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
   </picture>
 </p>
 
-**qte77** hosts a framework for compounding agentic work — keeping goals, specs, builds, and learnings in one feedback loop instead of drifting. Agents drive it; humans approve and steer. Proof: 30+ repos running on it here.
+**qte77** hosts a framework for compounding agentic work — keeping goals, specs, builds, and learnings in one feedback loop instead of drifting. Agents drive it; humans approve and steer.
+
+Proof: [30+ repos](https://github.com/qte77?tab=repositories) running on it; this README itself was shaped by agent PRs (e.g. [#83](https://github.com/qte77/qte77/pull/83), [#84](https://github.com/qte77/qte77/pull/84)).
 
 ## Mental Model
 


### PR DESCRIPTION
## Summary

- Replace the unsubstantiated "Proof: 30+ repos running on it here" suffix with a separate line linking:
  - The actual repo list (https://github.com/qte77?tab=repositories)
  - Two recent agent-authored, merged PRs that shaped this very README (#83, #84)
- No fabricated metrics — both PRs are real, agent-authored, and already merged

## Acceptance (from #67)

- [x] One real metric: linked 30+ repos
- [x] One linked example: agent-authored merged PRs (#83, #84)

## Test plan

- [ ] README renders cleanly; tagline + proof line both visible above the fold
- [ ] All three links resolve (repos page, PR #83, PR #84)
- [ ] CodeFactor passes

Closes #67.

Generated with Claude <noreply@anthropic.com>