### PR TITLE
docs(readme): add Positioning section between Roadmap and Lineage (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Each repo carries its own quickstart.
 - **Next** — spec-forge methodology landing in [claude-code-plugins](https://github.com/qte77/claude-code-plugins).
 - **Later** — runtime portability: air-gapped, BYOM, your stack.
 
+## Positioning
+
+qte77 is a cross-repo coordination layer, not a single-repo agent runner or per-prompt orchestrator. It assumes you already have agents (Claude Code, etc.) and need them to stop drifting across many repos.
+
+Reach for something else if you're building one agent for one repo, or your loop fits in a single prompt.
+
 ## Lineage
 
 How the current system got here — proof of work, not required reading.


### PR DESCRIPTION
## Summary

- New `## Positioning` section between Roadmap and Lineage
- 3 lines: "what this isn't" + "reach elsewhere if…"
- No specific framework names — avoids fabricating comparisons against tools the maintainer hasn't formally evaluated, and avoids a matrix that ages badly

## Acceptance (from #74)

- [x] One-line "what qte77 isn't"
- [x] Honest "when to use something else" line
- [ ] ~~2–4 row comparison table or framework-by-name contrast~~ — deliberately skipped per "Out of scope: Comparing against tools the maintainer hasn't actually evaluated"

## Test plan

- [ ] README renders cleanly; section appears between Roadmap and Lineage
- [ ] CodeFactor passes

Closes #74.

Generated with Claude <noreply@anthropic.com>