### PR TITLE
docs(readme): apply devil's-advocate review followups

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **qte77** hosts a framework for compounding agentic work — keeping goals, specs, builds, and learnings in one feedback loop instead of drifting. Agents drive it; humans approve and steer.
 
-Proof: [30+ repos](https://github.com/qte77?tab=repositories) running on it; this README itself was shaped by agent PRs (e.g. [#83](https://github.com/qte77/qte77/pull/83), [#84](https://github.com/qte77/qte77/pull/84)).
+Proof: [30+ repos](https://github.com/qte77?tab=repositories) running on it.
 
 ## Mental Model
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Read it as: goals at the top feed specs, specs feed builds, builds emit learning
 
 Policy, mechanism, and state get confused and duplicated across repos. Naming where each decision lives prevents the drift and keeps 30+ repos DRY.
 
-- **META** — policy (what we optimize for)
-- **KERNEL** — invariants (rules that must hold)
-- **MECHANISM** — code (how rules are enforced)
-- **STATE** — data (goals, specs, learnings)
-- **CONSUMERS** — repos (where it lands)
+- **META** — policy: what we optimize for (rules, principles)
+- **KERNEL** — invariants: rules that must hold (core-principles, compound-learning)
+- **MECHANISM** — code that enforces rules (skills, hooks, GHA pipelines)
+- **STATE** — data the system reads and writes (goals, specs, learnings)
+- **CONSUMERS** — where it lands (30+ companion repos)
 
 <details>
   <summary>Diagram: META, KERNEL, MECHANISM, STATE, CONSUMERS</summary>

--- a/lychee.toml
+++ b/lychee.toml
@@ -24,4 +24,9 @@ exclude = [
   # --- GitHub anchors / settings pages requiring auth ---
   "^https://github\\.com/.*/settings",
   "^https://github\\.com/.*/security/advisories/new",
+
+  # --- Private repos (404 to unauthenticated linker, intentional) ---
+  # AGENTS.md references a private project tracker; the 404 from the
+  # public CI runner is expected and not a broken link.
+  "^https://github\\.com/qte77/\\.github-private-project-tracker",
 ]


### PR DESCRIPTION
## Summary

Followups from a devil's-advocate review of README PRs #84, #85, #86, plus a CI fix uncovered along the way. Squash-merged; the three original commit messages are preserved below.

## Commits (squashed)

### 1. `docs(readme): anchor Authority Chain bullets to concrete artifacts`

Replace abstract parentheticals (policy, invariants, code, data, repos) with concrete anchors (rules, core-principles, skills/hooks/GHA, goals/specs/learnings, 30+ companion repos) so a reader can place new concepts in the taxonomy.

### 2. `docs(readme): drop circular agent-PR examples from Proof line`

Linking session-internal PRs as proof of "compounding agentic work" begs the question — those PRs only show agents can edit a README, not that the framework coordinates work across repos. Keep the 30+ repos link, which at least points at the cross-repo claim.

### 3. `ci(lychee): exclude private project tracker URL from link check`

AGENTS.md links to qte77/.github-private-project-tracker, which 404s for the public CI runner because the repo is private. The 404 is expected and not a broken link, so exclude the URL rather than letting it red-flag every PR.

## Notes

- #86 (Positioning) shipped as-is from the review — no-names choice was the right call.
- Lychee fix interpretation: added the URL to the `exclude` accept-list rather than adding `404` to the global status-code accept (which would mask every real broken link).

## Test plan

- [x] `lint / markdown` green
- [x] `lint / links` green
- [x] `CodeFactor` green
- [ ] Verify rendered README on github.com/qte77/qte77 post-merge

Generated with Claude <noreply@anthropic.com>