### PR TITLE
docs(readme): remove Proof line above Mental Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 
 **qte77** hosts a framework for compounding agentic work — keeping goals, specs, builds, and learnings in one feedback loop instead of drifting. Agents drive it; humans approve and steer.
 
-Proof: [30+ repos](https://github.com/qte77?tab=repositories) running on it.
-
 ## Mental Model
 
 Agentic development across 30+ repos drifts without a shared map. This fixes the feedback loop from learnings back to specs so the system compounds instead of forgetting.


### PR DESCRIPTION
## Summary

Single-commit PR. Removes the `Proof: 30+ repos running on it.` line above Mental Model.

A repos-list link shows what exists, not that the framework coordinates them — the claim doesn't earn its prose. Mental-model + Authority Chain + the "What this means concretely" prose already establish breadth and structure.

## What changed direction

This branch originally re-introduced `universe.svg` from the archive as a `<details>` block. On review, universe is a strict subset of `mental-model.svg` (mental-model has the same boxes plus flow arrows, SPECS, IMPLEMENT row, and the LEARN→SPECS feedback loop) — re-introducing it would have been a regression. Branch rewound to just the Proof-line removal; universe stays archived.

## Test plan

- [ ] `lint / markdown` green
- [ ] `lint / links` green
- [ ] `CodeFactor` green
- [ ] Verify rendered README on github.com/qte77/qte77 — flow Mental Model → Authority Chain reads cleanly without the Proof line

Generated with Claude <noreply@anthropic.com>