### PR TITLE
docs(readme): rewrite hero for SEO/GEO discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   </picture>
 </p>
 
-**qte77** hosts a framework for compounding agentic work — keeping goals, specs, builds, and learnings in one feedback loop instead of drifting. Agents drive it; humans approve and steer.
+**qte77** is a polyrepo orchestration framework for AI coding agents — coordinating Claude Code and compatible agents across 30+ repositories so goals, specs, builds, and learnings compound instead of drift. Agents drive it; humans approve and steer.
 
 ## Mental Model
 


### PR DESCRIPTION
  ## Summary
  - Rewrite README opening paragraph so the first 2 sentences carry searchable keywords
  - Lead with category ('polyrepo orchestration framework for AI coding agents'), name Claude Code, surface the 30+ repo scale claim
  - Second sentence (agents drive, humans steer) unchanged

  ## Why
  AI engines (ChatGPT, Claude, Perplexity) lift the first 1-3 sentences of a README verbatim when asked entity Q&A ('what is qte77'). The prior
  framing was poetic but unsearchable — nobody types 'framework for compounding agentic work'.

  ## Test plan
  - [ ] lint-md-links passes
  - [ ] Diagrams and downstream sections render unchanged
  - [ ] PROFILE.md left untouched (owner summary stays separate per editorial split)