### PR TITLE
ci(workflows): SHA-pin actions + route blog-post update through a PR

### DIFF
--- a/.github/workflows/blog-post-workflow.yml
+++ b/.github/workflows/blog-post-workflow.yml
@@ -1,21 +1,51 @@
 ---
 # https://github.com/gautamkrishnar/blog-post-workflow
 name: Latest blog post workflow
+
 on:
   schedule:
     # https://crontab.guru/#0_0_*_*_0
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-readme-with-blog:
     name: Update this repo's README with latest blog posts
     runs-on: ubuntu-latest
+    env:
+      BRANCH: chore/blog-posts-${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: gautamkrishnar/blog-post-workflow@v1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+
+      # `main` is protected (pull_request + required_signatures + linear history),
+      # so update via a feature branch, then PR + squash-merge: the squash commit is
+      # created (and signed) by GitHub, satisfying all three rules.
+      - name: Create update branch
+        run: |
+          git switch -c "$BRANCH"
+          git push -u origin "$BRANCH"
+
+      - uses: gautamkrishnar/blog-post-workflow@2786e54a01b71aec80a5118c2bd6b5044e842597  # v1.9.6
         with:
           max_post_count: "4"
           remove_duplicates: true
           feed_list: "https://qte77.github.io/feed"
-...
+
+      - name: PR + squash-merge if the README changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git fetch origin main "$BRANCH"
+          if git diff --quiet "origin/main" "origin/$BRANCH"; then
+            echo "No README changes — removing the empty branch."
+            git push origin --delete "$BRANCH" || true
+            exit 0
+          fi
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore: update README with latest blog posts" \
+            --body "Automated by blog-post-workflow."
+          gh pr merge "$BRANCH" --squash --delete-branch

--- a/.github/workflows/repo-registry.yml
+++ b/.github/workflows/repo-registry.yml
@@ -15,8 +15,8 @@ jobs:
   update-registry:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: qte77/gha-repo-index@main
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: qte77/gha-repo-index@dedae4378832debd739a0e21916d45b6802b383f  # v0.1.0
         with:
           OWNER: qte77
           OUTPUT_DIR: registry


### PR DESCRIPTION
Makes the two scheduled workflows compliant with the `main` ruleset (pull_request + required_signatures + required_linear_history) and the actions policy (`selected` + `sha_pinning_required`).

## blog-post-workflow.yml
- SHA-pin `actions/checkout` → v6.0.3, `gautamkrishnar/blog-post-workflow` → v1.9.6.
- It previously committed + pushed straight to `main`, which the ruleset rejects (`GH013`). It now updates the README on a feature branch, then opens a PR and **squash-merges** it — the squash commit is GitHub-signed and linear, satisfying all three rules. No approval needed (`required_approving_review_count: 0`).

## repo-registry.yml
- SHA-pin `actions/checkout` → v6.0.3, `qte77/gha-repo-index` → v0.1.0 (just tagged).

## Settings (already applied)
- Added `gautamkrishnar/blog-post-workflow@*` to the repo's allowed-actions `patterns_allowed`.

`lint-md-links.yml` was already SHA-pinned to a reusable workflow — unchanged.

Generated with Claude <noreply@anthropic.com>
