### PR TITLE
ci: pin gha-repo-index to v0.1.1

### DIFF
--- a/.github/workflows/repo-registry.yml
+++ b/.github/workflows/repo-registry.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
-      - uses: qte77/gha-repo-index@dedae4378832debd739a0e21916d45b6802b383f  # v0.1.0
+      - uses: qte77/gha-repo-index@7e5254358f01490e70ca524da82f46256602db70  # v0.1.1
         with:
           OWNER: qte77
           OUTPUT_DIR: registry


### PR DESCRIPTION
Bumps the `repo-registry` workflow's `qte77/gha-repo-index` pin from v0.1.0 to **v0.1.1** (`7e52543`).

v0.1.1 SHA-pins the action's own nested `actions/checkout@v6` to v6.0.3 — the unpinned ref was being rejected by this repo's `sha_pinning_required` Actions policy, which is what made the prior `Update Repo Registry` run fail. This is the root-cause fix.

Generated with Claude <noreply@anthropic.com>