### PR TITLE
fix(brand): reference border via valid sub-token (divider)

### DIFF
--- a/brand/DESIGN.md
+++ b/brand/DESIGN.md
@@ -39,8 +39,9 @@ components:
   card: { backgroundColor: "{colors.surface}", textColor: "{colors.text}", rounded: "{rounded.lg}", padding: "16px" }
   code: { backgroundColor: "{colors.surface}", textColor: "{colors.text}", typography: "{typography.mono}", rounded: "{rounded.sm}" }
   page: { backgroundColor: "{colors.bg}", textColor: "{colors.text}" }
-  input: { backgroundColor: "{colors.surface}", textColor: "{colors.text}", borderColor: "{colors.border}", rounded: "{rounded.sm}", padding: "6px 12px" }
+  input: { backgroundColor: "{colors.surface}", textColor: "{colors.text}", rounded: "{rounded.sm}", padding: "6px 12px" }
   caption: { textColor: "{colors.text-muted}", typography: "{typography.sans}" }
+  divider: { backgroundColor: "{colors.border}", height: "1px" }
 variants:
   green:                       # forest / yellow-green
     name: EyeRest Green


### PR DESCRIPTION
## What

Follow-up to the design.md lint pass. `@google/design.md` rejects
`borderColor` as a component sub-token (only `backgroundColor`, `textColor`,
`typography`, `rounded`, `padding`, `size`, `height`, `width` are valid).

## Fix

- Drop the invalid `borderColor` from `input`.
- Add a `divider` component (`backgroundColor: border`, `height: 1px`) so
  `border` stays referenced via a valid sub-token.

## Result

Clears the `input.borderColor` warning. Remaining lint output: **0 errors, 7
warnings** — all of them the `dark-*` scheme-override tokens, which the
single-palette design.md format cannot reference from a component (the accepted
floor; eliminating them would mean dropping dark mode from the file).

Generated with Claude <noreply@anthropic.com>