### PR TITLE
docs: drop Apache LICENSE APPENDIX section (end at END OF TERMS AND CONDITIONS)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,19 +175,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX:
-
-   Copyright 2026 qte77
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.


### PR DESCRIPTION
Removes the entire Apache LICENSE APPENDIX section so the file ends at the line `END OF TERMS AND CONDITIONS` (drops the bare APPENDIX: label, the copyright line, and the boilerplate grant).

Co-Authored-By: Claude <noreply@anthropic.com>