### PR TITLE
feat(brand): font-license SOT folder + accurate license docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `brand/scripts/install_fonts.py`, `brand/README.md`, `brand/Makefile`: corrected the inaccurate "all fonts are SIL OFL 1.1" claim — the downloader pulls three license families (OFL 1.1, Ubuntu Font Licence 1.0 for Ubuntu Mono, Bitstream Vera + Arev for the canonical DejaVu bake font); docs now list every downloaded font with its actual license and point to `fonts/LICENSES/`
 - `brand/scripts/svg_text_to_paths.py`: honor `letter-spacing` attribute when shaping; previously paths SVGs spaced glyphs further apart than the canonical text SVG (PR #55)
 
 ## [0.3.0] - 2026-04-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `brand/fonts/LICENSES/`: canonical, committed font-license texts — the single source of truth a consumer vendors a font *and* its license from. `OFL.txt` (SIL OFL 1.1, stacked copyright headers for Inter, JetBrains Mono, Cascadia, Fira, Source Code Pro, IBM Plex Mono), `DejaVu-LICENSE.txt` (Bitstream Vera + Arev), `UbuntuMono-UFL.txt` (Ubuntu Font Licence 1.0), and a `README.md` font→license manifest; `brand/.gitignore` un-ignores `LICENSES/` while font binaries stay ignored
 - `brand/social-previews.toml`: expanded from 1 to 12 repo entries covering the main estate (doc-pipeline-engine, paperverse, polyforge-orchestrator, claude-code-plugins, so101-biolab-automation, pseudonymize-text, i3mega-pipettebot, gha-issue-triage, diagramforge, agentic-job-offer-to-application-kit, ai-agents-research)
 - `CONTRIBUTING.md`: minimal workflow doc — scope, commands, Conventional Commits, branch naming, CHANGELOG rule, pre-merge checklist
 - `.markdownlint.jsonc`: project policy disabling MD013/MD041/MD060, allowing inline HTML

--- a/brand/.gitignore
+++ b/brand/.gitignore
@@ -2,6 +2,8 @@
 /dist/
 /scripts/__pycache__/
 
-# Fonts: directory tracked via .gitkeep only; binaries downloaded on demand
+# Fonts: binaries downloaded on demand (gitignored); only .gitkeep and the
+# committed license texts in LICENSES/ are tracked.
 /fonts/*
 !/fonts/.gitkeep
+!/fonts/LICENSES/

--- a/brand/Makefile
+++ b/brand/Makefile
@@ -20,7 +20,7 @@ SCRIPTS  := scripts
 # MARK: SETUP
 
 
-setup_brand_fonts:  ## Download Inter + JetBrains Mono (OFL) into brand/fonts/
+setup_brand_fonts:  ## Download brand fonts into brand/fonts/ (licenses in fonts/LICENSES/)
 	echo "Installing brand fonts ..."
 	uv run $(SCRIPTS)/install_fonts.py
 

--- a/brand/README.md
+++ b/brand/README.md
@@ -85,8 +85,16 @@ sources in [docs/github-image-theming.md](../docs/github-image-theming.md).
 
 ## Fonts
 
-- **Inter** (sans, headings) — [rsms/inter](https://github.com/rsms/inter), OFL
-- **JetBrains Mono** (mono, code) — [JetBrains/JetBrainsMono](https://github.com/JetBrains/JetBrainsMono), OFL
+`scripts/install_fonts.py` downloads these on demand (binaries gitignored). All
+are free/libre but under **three** licenses — canonical texts and the per-font
+mapping live in [`fonts/LICENSES/`](fonts/LICENSES/README.md):
+
+- **Inter** (sans, headings) — [rsms/inter](https://github.com/rsms/inter) — SIL OFL 1.1
+- **JetBrains Mono** (mono, code) — [JetBrains/JetBrainsMono](https://github.com/JetBrains/JetBrainsMono) — SIL OFL 1.1
+- **Cascadia Mono** (mark/wordmark) — [microsoft/cascadia-code](https://github.com/microsoft/cascadia-code) — SIL OFL 1.1
+- **Fira Mono**, **Source Code Pro**, **IBM Plex Mono** (bake variants) — SIL OFL 1.1
+- **Ubuntu Mono** (bake variant) — [Ubuntu Font Family](https://design.ubuntu.com/font) — Ubuntu Font Licence 1.0
+- **DejaVu Sans Mono** (canonical bake font) — [dejavu-fonts](https://github.com/dejavu-fonts/dejavu-fonts) — Bitstream Vera + Arev
 
 ## Usage
 

--- a/brand/fonts/LICENSES/DejaVu-LICENSE.txt
+++ b/brand/fonts/LICENSES/DejaVu-LICENSE.txt
@@ -1,0 +1,100 @@
+DejaVu Sans Mono is released under the Bitstream Vera Fonts license with the
+Arev modifications. The two applicable sections are reproduced verbatim below.
+Upstream: https://github.com/dejavu-fonts/dejavu-fonts
+See README.md in this directory for the font-to-license mapping.
+
+
+Bitstream Vera Fonts Copyright
+------------------------------
+
+Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is
+a trademark of Bitstream, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of the fonts accompanying this license ("Fonts") and associated
+documentation files (the "Font Software"), to reproduce and distribute the
+Font Software, including without limitation the rights to use, copy, merge,
+publish, distribute, and/or sell copies of the Font Software, and to permit
+persons to whom the Font Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright and trademark notices and this permission notice shall
+be included in all copies of one or more of the Font Software typefaces.
+
+The Font Software may be modified, altered, or added to, and in particular
+the designs of glyphs or characters in the Fonts may be modified and
+additional glyphs or characters may be added to the Fonts, only if the fonts
+are renamed to names not containing either the words "Bitstream" or the word
+"Vera".
+
+This License becomes null and void to the extent applicable to Fonts or Font
+Software that has been modified and is distributed under the "Bitstream
+Vera" names.
+
+The Font Software may be sold as part of a larger software package but no
+copy of one or more of the Font Software typefaces may be sold by itself.
+
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT,
+TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL BITSTREAM OR THE GNOME
+FOUNDATION BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING
+ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF
+THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE
+FONT SOFTWARE.
+
+Except as contained in this notice, the names of Gnome, the Gnome
+Foundation, and Bitstream Inc., shall not be used in advertising or
+otherwise to promote the sale, use or other dealings in this Font Software
+without prior written authorization from the Gnome Foundation or Bitstream
+Inc., respectively. For further information, contact: fonts at gnome dot
+org.
+
+Arev Fonts Copyright
+------------------------------
+
+Copyright (c) 2006 by Tavmjong Bah. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the fonts accompanying this license ("Fonts") and
+associated documentation files (the "Font Software"), to reproduce
+and distribute the modifications to the Bitstream Vera Font Software,
+including without limitation the rights to use, copy, merge, publish,
+distribute, and/or sell copies of the Font Software, and to permit
+persons to whom the Font Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright and trademark notices and this permission notice
+shall be included in all copies of one or more of the Font Software
+typefaces.
+
+The Font Software may be modified, altered, or added to, and in
+particular the designs of glyphs or characters in the Fonts may be
+modified and additional glyphs or characters may be added to the
+Fonts, only if the fonts are renamed to names not containing either
+the words "Tavmjong Bah" or the word "Arev".
+
+This License becomes null and void to the extent applicable to Fonts
+or Font Software that has been modified and is distributed under the
+"Tavmjong Bah Arev" names.
+
+The Font Software may be sold as part of a larger software package but
+no copy of one or more of the Font Software typefaces may be sold by
+itself.
+
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL
+TAVMJONG BAH BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
+Except as contained in this notice, the name of Tavmjong Bah shall not
+be used in advertising or otherwise to promote the sale, use or other
+dealings in this Font Software without prior written authorization
+from Tavmjong Bah. For further information, contact: tavmjong @ free
+. fr.

--- a/brand/fonts/LICENSES/OFL.txt
+++ b/brand/fonts/LICENSES/OFL.txt
@@ -1,0 +1,104 @@
+This file bundles the SIL Open Font License (OFL), Version 1.1, for every
+OFL-licensed font vendored by brand/scripts/install_fonts.py. The copyright
+and Reserved Font Name notices for each bundled font are stacked below, ahead
+of the single shared license body. See README.md in this directory for the
+font-to-license mapping.
+
+Copyright (c) 2016 The Inter Project Authors (https://github.com/rsms/inter)
+Copyright 2020 The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono)
+Copyright (c) 2019 - Present, Microsoft Corporation, with Reserved Font Name Cascadia Code.
+Digitized data copyright (c) 2012-2015, The Mozilla Foundation and Telefonica S.A., with Reserved Font Name < Fira >.
+© 2023 Adobe (http://www.adobe.com/), with Reserved Font Name 'Source'. All Rights Reserved. Source is a trademark of Adobe in the United States and/or other countries.
+Copyright © 2017 IBM Corp. with Reserved Font Name "Plex"
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/brand/fonts/LICENSES/README.md
+++ b/brand/fonts/LICENSES/README.md
@@ -1,0 +1,36 @@
+# Font licenses
+
+Canonical license texts for every font downloaded by
+[`../../scripts/install_fonts.py`](../../scripts/install_fonts.py). The font
+binaries themselves are gitignored (fetched on demand); these license files are
+committed so this folder is the single source of truth a consumer vendors a
+font *and* its license from — no downstream repo hand-maintains a copy.
+
+All fonts here are free/libre and redistributable, but under **three different
+licenses** — not all are OFL. Match each `.ttf` to its license below.
+
+| Font file(s) | Family | License | Reserved Font Name | Text |
+| ------------ | ------ | ------- | ------------------ | ---- |
+| `Inter-Regular.ttf`, `Inter-Bold.ttf` | Inter | SIL OFL 1.1 | — | [`OFL.txt`](OFL.txt) |
+| `JetBrainsMono-Regular.ttf`, `JetBrainsMono-Bold.ttf` | JetBrains Mono | SIL OFL 1.1 | — | [`OFL.txt`](OFL.txt) |
+| `CascadiaMono-Bold.ttf` | Cascadia Code | SIL OFL 1.1 | Cascadia Code | [`OFL.txt`](OFL.txt) |
+| `FiraMono-Bold.ttf` | Fira Mono | SIL OFL 1.1 | Fira | [`OFL.txt`](OFL.txt) |
+| `SourceCodePro-Bold.ttf` | Source Code Pro | SIL OFL 1.1 | Source | [`OFL.txt`](OFL.txt) |
+| `IBMPlexMono-Bold.ttf` | IBM Plex Mono | SIL OFL 1.1 | Plex | [`OFL.txt`](OFL.txt) |
+| `DejaVuSansMono-Bold.ttf` | DejaVu Sans Mono | Bitstream Vera + Arev | — | [`DejaVu-LICENSE.txt`](DejaVu-LICENSE.txt) |
+| `UbuntuMono-Bold.ttf` | Ubuntu Mono | Ubuntu Font Licence 1.0 | — | [`UbuntuMono-UFL.txt`](UbuntuMono-UFL.txt) |
+
+## Vendoring a font downstream
+
+When a consumer repo self-hosts one of these fonts (ships the `.ttf`), copy the
+matching license text from this folder next to the font, e.g.:
+
+```text
+ui/src/assets/fonts/Inter-Regular.ttf   # the font
+ui/src/assets/fonts/OFL.txt             # from brand/fonts/LICENSES/OFL.txt
+```
+
+The license must travel with the font (OFL §2, UFL §1, Bitstream Vera). Rendered
+output — rasterized PNGs, path-baked SVGs — counts as a *document created using
+the font* and carries no such obligation, which is why this repo's committed
+`brand/images/` artifacts need no bundled license.

--- a/brand/fonts/LICENSES/UbuntuMono-UFL.txt
+++ b/brand/fonts/LICENSES/UbuntuMono-UFL.txt
@@ -1,0 +1,57 @@
+Ubuntu Mono is part of the Ubuntu Font Family.
+Copyright 2010-2011 Canonical Ltd. Licensed under the Ubuntu Font Licence,
+Version 1.0. Upstream: https://design.ubuntu.com/font
+See README.md in this directory for the font-to-license mapping.
+
+
+-------------------------------
+UBUNTU FONT LICENCE Version 1.0
+-------------------------------
+
+PREAMBLE
+
+This licence allows the licensed fonts to be used, studied, modified and redistributed freely. The fonts, including any derivative works, can be bundled, embedded, and redistributed provided the terms of this licence are met. The fonts and derivatives, however, cannot be released under any other licence. The requirement for fonts to remain under this licence does not require any document created using the fonts or their derivatives to be published under this licence, as long as the primary purpose of the document is not to be a vehicle for the distribution of the fonts.
+
+DEFINITIONS
+
+"Font Software" refers to the set of files released by the Copyright Holder(s) under this licence and clearly marked as such. This may include source files, build scripts and documentation.
+
+"Original Version" refers to the collection of Font Software components as received under this licence.
+
+"Modified Version" refers to any derivative made by adding to, deleting, or substituting — in part or in whole — any of the components of the Original Version, by changing formats or by porting the Font Software to a new environment.
+
+"Copyright Holder(s)" refers to all individuals and companies who have a copyright ownership of the Font Software.
+
+"Substantially Changed" refers to Modified Versions which can be easily identified as dissimilar to the Font Software by users of the Font Software comparing the Original Version with the Modified Version.
+
+To "Propagate" a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy. Propagation includes copying, distribution (with or without modification and with or without charging a redistribution fee), making available to the public, and in some countries other activities as well.
+
+PERMISSION & CONDITIONS
+
+This licence does not grant any rights under trademark law and all such rights are reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of the Font Software, to propagate the Font Software, subject to the below conditions:
+
+1. Each copy of the Font Software must contain the above copyright notice and this licence. These can be included either as stand-alone text files, human-readable headers or in the appropriate machine-readable metadata fields within text or binary files as long as those fields can be easily viewed by the user.
+
+2. The font name complies with the following:
+   1. The Original Version must retain its name, unmodified.
+   2. Modified Versions which are Substantially Changed must be renamed to avoid use of the name of the Original Version or similar names entirely.
+   3. Modified Versions which are not Substantially Changed must be renamed to both
+      1. retain the name of the Original Version and
+      2. add additional naming elements to distinguish the Modified Version from the Original Version. The name of such Modified Versions must be the name of the Original Version, with "derivative X" where X represents the name of the new work, appended to that name.
+
+3. The name(s) of the Copyright Holder(s) and any contributor to the Font Software shall not be used to promote, endorse or advertise any Modified Version, except
+   1. as required by this licence,
+   2. to acknowledge the contribution(s) of the Copyright Holder(s) or
+   3. with their explicit written permission.
+
+4. The Font Software, modified or unmodified, in part or in whole, must be distributed entirely under this licence, and must not be distributed under any other licence. The requirement for fonts to remain under this licence does not affect any document created using the Font Software, except any version of the Font Software extracted from a document created using the Font Software may only be distributed under this licence.
+
+TERMINATION
+
+This licence becomes null and void if any of the above conditions are not met.
+
+DISCLAIMER
+
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/brand/scripts/install_fonts.py
+++ b/brand/scripts/install_fonts.py
@@ -4,16 +4,19 @@
 # ///
 """Download brand fonts into brand/fonts/.
 
-All fonts are SIL OFL 1.1 (or compatible) and free to redistribute:
-- Inter (sans, headings) — Fontsource CDN
-- JetBrains Mono (mono, social-preview taglines) — Fontsource CDN
-- Cascadia Mono (mark/wordmark default) — Fontsource CDN
-- DejaVu Sans Mono, Liberation Mono — Linux defaults; raw GitHub via jsdelivr
-- Fira Mono, Source Code Pro — additional Linux-leaning monos via Fontsource
+All fonts are free/libre and redistributable, but under three different
+licenses — not all are OFL. Canonical license texts and the per-font
+mapping live in fonts/LICENSES/ (committed; the .ttf binaries are not):
+- Inter (sans, headings) — SIL OFL 1.1 — Fontsource CDN
+- JetBrains Mono (mono, social-preview taglines) — SIL OFL 1.1 — Fontsource CDN
+- Cascadia Mono (mark/wordmark default) — SIL OFL 1.1 — Fontsource CDN
+- Fira / Source Code Pro / IBM Plex Mono — SIL OFL 1.1 — Fontsource CDN
+- Ubuntu Mono — Ubuntu Font Licence 1.0 — Fontsource CDN
+- DejaVu Sans Mono — Bitstream Vera + Arev — GitHub release zip
 
-The Linux monos are available so brand_paths can bake .paths.svg
-variants from each, letting consumers pick the closest match to what
-their viewers' systems render."""
+The extra monos are available so brand_paths can bake .paths.svg variants
+from each, letting consumers pick the closest match to what their viewers'
+systems render. DejaVu Sans Mono Bold is the canonical bake font."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
Makes `brand/fonts/LICENSES/` the single source of truth a consumer vendors a font *and* its license from, and corrects the docs that wrongly claimed every downloaded font is OFL.

## Commits (squash-merge collapses these)

**feat(brand): add font-license SOT folder (brand/fonts/LICENSES/)**
Commit the canonical license texts for every font `install_fonts.py` downloads. `OFL.txt` bundles SIL OFL 1.1 with stacked copyright headers for the six OFL fonts (Inter, JetBrains Mono, Cascadia, Fira, Source Code Pro, IBM Plex Mono); `DejaVu-LICENSE.txt` holds Bitstream Vera + Arev; `UbuntuMono-UFL.txt` holds Ubuntu Font Licence 1.0; `README.md` is the font→license manifest. `.gitignore` un-ignores `LICENSES/` while font binaries stay ignored.

**fix(brand): correct inaccurate "all fonts are OFL" license docs**
The downloader pulls three license families, not just OFL. The `install_fonts.py` docstring, `brand/README.md` Fonts section, and `Makefile` help line now list every downloaded font with its actual license and point to `fonts/LICENSES/`.

## Notes
- License texts were fetched verbatim from upstream (rsms/inter, JetBrains, microsoft/cascadia-code, adobe-fonts, IBM/plex, dejavu-fonts, canonical.com), not reconstructed.
- The repo's committed `brand/images/` artifacts are DejaVu-baked *documents* and carry no bundling obligation; this PR adds the SOT consumers vendor *from*, not a copy step (the brand repo has no font→consumer vendoring stage).
- Out of scope: paperverse can later source its `OFL.txt` from this folder (a second-consumer follow-up).

## Validation
- markdownlint clean
- lychee `--offline` clean (0 errors; `brand/fonts` excluded by `lychee.toml`)
- `install_fonts.py` parses; `git check-ignore` confirms font binaries stay ignored while license files are tracked

Generated with Claude <noreply@anthropic.com>