### PR TITLE
feat(brand): EyeRest ui-kit + optional verify gate + GUI-baseline findings

### DIFF
--- a/brand/README.md
+++ b/brand/README.md
@@ -5,6 +5,8 @@ Design tokens, logo, and font references for qte77 visual identity.
 ## Files
 
 - `DESIGN.md` — design tokens + color system (EyeRest, light + dark; google-labs-code design.md format)
+- `ui-kit/` — the no-build UI theme generated from `DESIGN.md` (EyeRest color/layout/fonts
+  CSS + theme cycler + a11y); see [`ui-kit/BASELINE.md`](ui-kit/BASELINE.md)
 - `images/logo-mark.text.svg` / `logo-mark.paths.dejavu.svg` — square mark; canonical text + path-baked variant
 - `images/logo-wordmark.text.svg` / `logo-wordmark.paths.dejavu.svg` — wordmark; same pair
 - `images/avatar_dark.dejavu.png` / `images/avatar_light.dejavu.png` — 920×920 PNG
@@ -12,7 +14,8 @@ Design tokens, logo, and font references for qte77 visual identity.
   `scripts/render_avatar.py`)
 - `fonts/` — typography (downloaded by `scripts/install_fonts.py`, gitignored)
 - `scripts/` — Python tooling (font download, avatar render, social
-  preview render, SVG text-to-paths conversion)
+  preview render, SVG text-to-paths conversion, `render_og.py` OG/figure cards,
+  `gui-check.py` optional polyfetch UI verifier)
 - `Makefile` — entry point for all the above; see `make -C brand help`
 
 <details>

--- a/brand/scripts/gui-check.py
+++ b/brand/scripts/gui-check.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""gui-check.py — the qte77 check-and-fetch UI verifier (dual-scope).
+
+Runs over polyfetch-scrape's bundled Patchright — the single shared browser stack, no
+per-repo install. Recommended (OPTIONAL, not a required CI gate) to check & fetch a
+qte77-branded UI headlessly, early — before real users hit the page. See
+brand/ui-kit/ci-verify.example.yml to opt into CI.
+
+Two scopes, one codebase:
+  * single-repo / in-project:  gui-check.py --url http://localhost:8137
+  * cross-repo / multi-project: gui-check.py --urls urls.txt   (drift sweep)
+
+The cross-repo sweep audits each deployed UI's *live computed tokens* against the canonical
+EyeRest set (synced from brand/DESIGN.md) — this is what establishes the baseline and
+prevents drift. It is the GUI analogue of repo-baseline's audit.sh.
+
+Run via the shared env:
+  uv run --directory /workspaces/qte77/polyfetch-scrape patchright install chromium   # once
+  uv run --directory /workspaces/qte77/polyfetch-scrape python gui-check.py --url <url>
+
+Gotchas honored (see findings/04): SwiftShader flags for headless WebGL; do NOT nest
+sync_playwright() with polyfetch's attempt(); a reachable 200 page needs Patchright (not
+fetch()) to execute JS.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from patchright.sync_api import sync_playwright
+
+# Canonical EyeRest tokens — SYNCED from brand/DESIGN.md (single source of truth, D5).
+# gui-baseline regenerates this block from DESIGN.md; do not hand-edit independently.
+CANONICAL = {
+    "light": {
+        "--bg": "#ece8d8", "--surface": "#e2dec8", "--border": "#c8c4b0",
+        "--text": "#2c2818", "--text-muted": "#686040",
+        "--primary": "#7a6010", "--primary-on": "#ece8d8",
+        "--data-positive": "#4a6818", "--data-caution": "#787010",
+        "--data-negative": "#983828", "--data-alt": "#587818",
+    },
+    "dark": {
+        "--bg": "#1c1a14", "--surface": "#242018", "--border": "#383428",
+        "--text": "#d8d0b8", "--text-muted": "#a89878",
+        "--primary": "#c8a858", "--primary-on": "#1c1a14",
+        "--data-positive": "#8aa860", "--data-caution": "#c8b868",
+        "--data-negative": "#c08060", "--data-alt": "#a8b870",
+    },
+}
+
+# Headless Chromium has no GPU → SwiftShader. WebGL canvases need these or the context is
+# lost and the screenshot is blank. Harmless for 2D canvas / DOM-only pages.
+LAUNCH_ARGS = ["--enable-unsafe-swiftshader", "--ignore-gpu-blocklist"]
+
+
+def _norm(v: str) -> str:
+    return (v or "").strip().lower()
+
+
+def audit_tokens(page, theme: str) -> list[str]:
+    """Force a scheme, read the live computed tokens, diff against canonical. -> failures."""
+    page.evaluate("t => document.documentElement.setAttribute('data-theme', t)", theme)
+    names = list(CANONICAL[theme].keys())
+    computed = page.evaluate(
+        """names => {
+            const s = getComputedStyle(document.documentElement);
+            const o = {};
+            for (const n of names) o[n] = s.getPropertyValue(n);
+            return o;
+        }""",
+        names,
+    )
+    fails = []
+    for n, expected in CANONICAL[theme].items():
+        got = _norm(computed.get(n, ""))
+        if got != _norm(expected):
+            fails.append(f"[{theme}] {n}: expected {expected}, got {got or '(unset)'}")
+    return fails
+
+
+def check_a11y(page) -> list[str]:
+    """Theme control must have a dynamic accessible name + a live-region announce."""
+    fails = []
+    info = page.evaluate(
+        """() => {
+            const b = document.getElementById('theme-toggle');
+            const s = document.getElementById('theme-status');
+            return {
+                hasBtn: !!b,
+                label: b ? (b.getAttribute('aria-label') || '') : '',
+                hasLive: !!s && s.getAttribute('aria-live') === 'polite',
+            };
+        }"""
+    )
+    if not info["hasBtn"]:
+        fails.append("a11y: #theme-toggle missing")
+    elif "theme" not in info["label"].lower():
+        fails.append(f"a11y: #theme-toggle aria-label not descriptive ({info['label']!r})")
+    if not info["hasLive"]:
+        fails.append("a11y: #theme-status aria-live=polite region missing")
+    return fails
+
+
+def check_fonts(page) -> list[str]:
+    ok = page.evaluate(
+        """async () => {
+            await document.fonts.ready;
+            return document.fonts.check('400 16px Inter')
+                && document.fonts.check('700 16px Inter');
+        }"""
+    )
+    return [] if ok else ["fonts: Inter 400/700 not loaded (document.fonts.check failed)"]
+
+
+def check_favicon(page) -> list[str]:
+    try:
+        status = page.evaluate(
+            "async () => (await fetch('favicon.svg', {method:'GET'})).status"
+        )
+    except Exception:
+        return ["favicon: fetch threw (favicon.svg unreachable)"]
+    return [] if status == 200 else [f"favicon: favicon.svg returned {status}"]
+
+
+def check_webgl(page) -> list[str]:
+    info = page.evaluate(
+        """() => {
+            const c = document.querySelector('canvas');
+            if (!c) return {canvas: false};
+            const gl = c.getContext('webgl2') || c.getContext('webgl');
+            if (!gl) return {canvas: true, gl: false};
+            return {canvas: true, gl: true,
+                    lost: gl.isContextLost(),
+                    pointRange: gl.getParameter(gl.ALIASED_POINT_SIZE_RANGE)};
+        }"""
+    )
+    if not info.get("canvas"):
+        return []  # not a canvas GUI — skip
+    if not info.get("gl"):
+        return ["webgl: canvas present but no WebGL context"]
+    if info.get("lost"):
+        return ["webgl: context lost (missing --enable-unsafe-swiftshader?)"]
+    return []
+
+
+def check_url(pw, url: str, out_dir: Path, *, webgl: bool) -> list[str]:
+    """Run the full gate against one URL. Returns a list of failure strings."""
+    fails: list[str] = []
+    browser = pw.chromium.launch(headless=True, args=LAUNCH_ARGS)
+    try:
+        page = browser.new_page(viewport={"width": 1280, "height": 900})
+        page.goto(url, wait_until="networkidle")
+
+        for theme in ("light", "dark"):
+            fails += audit_tokens(page, theme)
+            shot = out_dir / f"{_slug(url)}-{theme}.png"
+            page.screenshot(path=str(shot), full_page=False)
+
+        fails += check_a11y(page)
+        fails += check_fonts(page)
+        fails += check_favicon(page)
+        if webgl:
+            fails += check_webgl(page)
+    finally:
+        browser.close()
+    return fails
+
+
+def _slug(url: str) -> str:
+    return "".join(c if c.isalnum() else "-" for c in url).strip("-")[:60]
+
+
+def _load_urls(args) -> list[str]:
+    if args.url:
+        return [args.url]
+    if args.urls:
+        p = Path(args.urls)
+        if p.exists():
+            return [ln.strip() for ln in p.read_text().splitlines() if ln.strip()]
+        return [u.strip() for u in args.urls.split(",") if u.strip()]
+    return []
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="qte77 GUI pre-user check-and-fetch gate")
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--url", help="single-repo / in-project: one URL (e.g. localhost)")
+    g.add_argument("--urls", help="cross-repo: a file (one URL/line) or comma list")
+    ap.add_argument("--org", help="(future) resolve deployed URLs from orgs/<org>.yaml")
+    ap.add_argument("--out", default="gui-check-out", help="screenshot output dir")
+    ap.add_argument("--webgl", action="store_true", help="also run WebGL sanity")
+    args = ap.parse_args()
+
+    if args.org:
+        print("note: --org resolution from orgs/<org>.yaml is a gui-baseline tool;",
+              "pass --urls with the deployed URLs for now.", file=sys.stderr)
+
+    urls = _load_urls(args)
+    if not urls:
+        print("error: no URLs to check", file=sys.stderr)
+        return 2
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    total_fails = 0
+    # ONE sync_playwright context for the whole run — never nest it with attempt().
+    with sync_playwright() as pw:
+        for url in urls:
+            print(f"\n=== {url} ===")
+            fails = check_url(pw, url, out_dir, webgl=args.webgl)
+            if fails:
+                total_fails += len(fails)
+                for f in fails:
+                    print(f"  FAIL  {f}")
+            else:
+                print("  OK    tokens · a11y · fonts · favicon"
+                      + (" · webgl" if args.webgl else ""))
+
+    print(f"\n{'DRIFT' if total_fails else 'CLEAN'}: "
+          f"{total_fails} failure(s) across {len(urls)} URL(s). "
+          f"Screenshots in {out_dir}/")
+    return 1 if total_fails else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/brand/scripts/render_og.py
+++ b/brand/scripts/render_og.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""render_og.py — UI-branding OG / figure card renderer (cairosvg).
+
+Hand-authored SVG → PNG at 1200×630 (in-content OG / figure cards, EyeRest palette).
+This is the UI-branding diagram pipeline (decision D8). It is SEPARATE from repo social
+previews (1280×640, GitHub branding) produced by brand/scripts/generate_social.py — same
+cairosvg mechanism, different size + palette + purpose; do not merge them.
+
+This renderer is the consolidation target for the org's scattered bash/awk SVG renderers
+(qte77/qte77#112).
+
+Usage:
+  uv run --with cairosvg python render_og.py images/foo.svg            # -> images/foo.png
+  uv run --with cairosvg python render_og.py images/foo.svg out.png
+
+Authoring rules (baked in as a pre-render lint):
+  * Canvas 1200×630; use EyeRest tokens (warm, zero-blue) — see brand/DESIGN.md.
+  * cairosvg's fallback font lacks → ≈ ² and renders them as tofu in <text>. Use an
+    en-dash, '~', and '^2' (or drawn arrow paths) instead.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import cairosvg
+
+OG_WIDTH, OG_HEIGHT = 1200, 630
+
+# glyphs cairosvg renders as tofu inside <text> -> safe replacements (findings/04).
+TOFU = {"→": "– (en-dash) or a drawn arrow", "≈": "~", "²": "^2"}
+
+
+def lint_svg(svg_path: Path) -> list[str]:
+    """Warn on tofu-prone glyphs that appear inside <text> elements."""
+    text = svg_path.read_text(encoding="utf-8")
+    warnings = []
+    for chunk in re.findall(r"<text\b[^>]*>(.*?)</text>", text, flags=re.DOTALL):
+        for glyph, fix in TOFU.items():
+            if glyph in chunk:
+                warnings.append(f"tofu risk: {glyph!r} in <text> — use {fix}")
+    return warnings
+
+
+def render(svg_path: Path, png_path: Path) -> None:
+    cairosvg.svg2png(
+        url=str(svg_path),
+        write_to=str(png_path),
+        output_width=OG_WIDTH,
+        output_height=OG_HEIGHT,
+    )
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print(__doc__)
+        return 2
+    svg_path = Path(argv[0])
+    png_path = Path(argv[1]) if len(argv) > 1 else svg_path.with_suffix(".png")
+    if not svg_path.exists():
+        print(f"error: {svg_path} not found", file=sys.stderr)
+        return 2
+
+    for w in lint_svg(svg_path):
+        print(f"  WARN  {w}", file=sys.stderr)
+
+    render(svg_path, png_path)
+    print(f"rendered {svg_path} -> {png_path} ({OG_WIDTH}x{OG_HEIGHT})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/brand/ui-kit/BASELINE.md
+++ b/brand/ui-kit/BASELINE.md
@@ -1,0 +1,122 @@
+# GUI baseline — findings & actionable roadmap
+
+Consolidated from a review of four qte77 GUIs (qte77.github.io, paperverse,
+analyze-stock-kpi, agentic-job-offer-to-application-kit) and how each verified its UI with
+`polyfetch-scrape`. This is the rationale behind [`brand/ui-kit/`](README.md): the shared,
+no-build EyeRest theming used by every qte77-branded UI.
+
+## Two brandings — GitHub vs UI
+
+qte77 runs **two distinct brandings** with different jobs. The `ui-kit/` carries **only UI
+branding**. Never pull GitHub-blue into the app; never repaint the GitHub mark in EyeRest.
+
+| | GitHub branding | UI branding |
+|---|---|---|
+| Purpose | identity inside GitHub's chrome (avatar, README, social cards) | the product GUIs (dashboards, Pages, in-app figures) |
+| Source | `brand/images/*`, `brand/scripts/generate_social.py` | `brand/DESIGN.md` → `brand/ui-kit/` |
+| Palette | GitHub Primer — blue accent `#388bfd` / `#1f6feb` on `#0d1117` / `#ffffff` | EyeRest — zero-blue, warm umber/parchment, amber primary |
+| Cards | repo social previews **1280×640** | in-content OG/figure cards **1200×630** |
+
+The brand mark is deliberately GitHub-blue so it blends into GitHub's UI — that is not an
+EyeRest violation, because EyeRest's zero-blue rule governs the app, not the chrome asset.
+
+## The unified UI baseline
+
+The four GUIs already converged on one theme contract; the kit packages it. A qte77-branded
+UI is conformant when it:
+
+1. Resolves theme by precedence `?theme=` › `localStorage['qte77-theme']` ›
+   `prefers-color-scheme`, restricted to `system | light | dark`.
+2. Applies via `html[data-theme="light|dark"]`; for `system`, leaves the attribute unset so
+   `prefers-color-scheme` governs.
+3. Guards FOUC with an inline `<head>` IIFE that does (1)+(2) before first paint.
+4. Cycles `system → light → dark` from one `#theme-toggle` button showing `◐ / ○ / ●`.
+5. Is accessible: dynamic `aria-label`/`title`, a `role="status" aria-live="polite"`
+   `.sr-only` announce region, a width-sizer (no reflow on cycle), `prefers-reduced-motion`,
+   keyboard + Escape.
+6. Emits a `themechange` event so charts/canvases recolour on flip.
+7. Sources tokens from the generated `eyerest.css` — no per-repo vendored copy.
+
+The reference implementation for the cycler + a11y is `analyze-stock-kpi`; the apply
+mechanism + inline guard come from qte77.github.io / paperverse. The kit must stay
+**no-build** (plain CSS + ES modules) because `agentic-job-offer-to-application-kit` ships
+without a bundler.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| D1 | Apply mechanism = `html[data-theme]` | cleaner `<head>` guard; 3 of 4 already use it |
+| D2 | Toggle glyphs = `◐ ○ ●` (System/Light/Dark) | 3 of 4 already use it |
+| D3 | a11y reference = `analyze-stock-kpi` | only one with dynamic `aria-label` + `aria-live` + width-sizer |
+| D4 | `localStorage` key = `qte77-theme` | standardize the divergent keys |
+| D5 | Tokens have one source of truth = `DESIGN.md` | CSS is generated; no second tokens source |
+| D6 | Home = `brand/ui-kit/` (next to `DESIGN.md`) | tightest DRY; no new repo, no cross-repo token hop |
+| D7 | Favicon = open decision (recommend EyeRest-tinted mark) | keeps the UI zero-blue; GitHub avatar stays Primer-blue |
+| D8 | OG cards split by branding | 1200×630 figure cards (UI) vs 1280×640 repo social (GitHub) |
+| D9 | Default CSS split into color / layout / fonts | matches `DESIGN.md` sections; pull only what you need |
+| D10 | Fonts: WOFF2 for web, TTF kept for baking | smallest web payload; cairosvg/fonttools need desktop formats |
+
+## Tokens & CSS
+
+`DESIGN.md` is the single source of truth (D5). The CSS is generated from it and split (D9):
+
+- [`eyerest.css`](eyerest.css) — color: default + 3 variants (Green/BluBlock/Dusk),
+  light/dark, zero-blue data arc. Selected via `html[data-variant="…"]`.
+- [`layout.css`](layout.css) — spacing (8px unit), radii (4/6/12px), container (768px),
+  component bindings.
+- [`fonts.css`](fonts.css) — `@font-face` (WOFF2 + TTF fallback), Inter + JetBrains Mono.
+
+All reference tokens — never a raw hex. `--primary` is the deepened `#7a6010` / `#c8a858`
+(WCAG AA on `--primary-on`).
+
+## Verify with polyfetch — optional, recommended
+
+Every qte77-branded UI can **check & fetch its UI headlessly, early, before users** with the
+shared [`qte77/polyfetch-scrape`](https://github.com/qte77/polyfetch-scrape) stack. It is the
+recommended way to catch branding/render defects pre-deploy — **optional, not a required CI
+gate** (see [`ci-verify.example.yml`](ci-verify.example.yml) for opt-in CI).
+
+[`../scripts/gui-check.py`](../scripts/gui-check.py) is dual-scope:
+
+- **single-repo / in-project** — render your local/staging URL and assert EyeRest tokens,
+  theme cycle, a11y, fonts, favicon, WebGL.
+- **cross-repo / multi-project** — sweep deployed URLs and audit live computed tokens
+  against `DESIGN.md` (drift detection).
+
+```bash
+uv run --directory ../polyfetch-scrape patchright install chromium          # once
+uv run --directory ../polyfetch-scrape python brand/scripts/gui-check.py --url http://localhost:8137
+uv run --directory ../polyfetch-scrape python brand/scripts/gui-check.py --urls urls.txt
+```
+
+`--directory` points at wherever the `polyfetch-scrape` checkout lives.
+
+## Portable gotchas
+
+| Gotcha | Fix |
+|---|---|
+| cairosvg tofu on `→ ≈ ²` in SVG `<text>` | use en-dash, `~`, `^2` / drawn arrows |
+| `WebGPURenderer` ignores `gl_PointSize` | use the classic `WebGLRenderer` for `THREE.Points` |
+| headless WebGL blank | launch with `--enable-unsafe-swiftshader --ignore-gpu-blocklist` |
+| nested `sync_playwright()` throws | run polyfetch's `attempt()` outside your own context |
+| `fetch()` won't JS-render a 200 page | drive Patchright directly to execute JS |
+
+## Actionable items
+
+- [ ] Add a `make ui-kit` target that **generates** `eyerest.css` / `layout.css` /
+      `fonts.css` from `DESIGN.md` (keep them in sync; today they are faithful hand-renders).
+- [ ] Update `scripts/install_fonts.py` to emit **WOFF2** (web) alongside TTF (baking).
+- [ ] Decide the favicon (D7): EyeRest-tinted mark variant vs. reuse the Primer-blue mark.
+- [ ] Promote `scripts/gui-check.py` to `repo-baseline/tools/` for the cross-repo drift
+      sweep (the org-wide baseline/drift home); keep the brand copy or symlink.
+- [ ] Wire the existing GUIs onto the kit (start with `analyze-stock-kpi`, the reference).
+- [ ] Update issues #111 (shared ui-kit) and #112 (SVG/diagram pipeline) with this placement.
+- [ ] (optional) Adopt `ci-verify.example.yml` in projects that want the gate in CI.
+
+## References
+
+- `DESIGN.md` — EyeRest tokens (source of truth).
+- `scripts/gui-check.py` — the polyfetch verify gate · `scripts/render_og.py` — OG/figure
+  pipeline (1200×630).
+- Issues #111 (shared ui-kit) · #112 (SVG/diagram pipeline consolidation).

--- a/brand/ui-kit/README.md
+++ b/brand/ui-kit/README.md
@@ -1,0 +1,68 @@
+# `brand/ui-kit/` — qte77 default UI theme (EyeRest)
+
+The no-build UI-branding kit, generated from [`../DESIGN.md`](../DESIGN.md) and living next
+to it so the CSS sits beside its source of truth. This is the **UI branding** (the product
+GUI); `../images/` is the **GitHub branding** (avatar, logo-mark). The two are distinct
+systems — never pull GitHub-blue into the app. See [`BASELINE.md`](BASELINE.md) for the full
+rationale and decisions.
+
+> **Provenance.** `eyerest.css`, `layout.css`, and `fonts.css` are **generated from
+> `../DESIGN.md`** — do not hand-edit. The token source of truth is `DESIGN.md`.
+
+## Contents
+
+| File | From `DESIGN.md` | What |
+|---|---|---|
+| `eyerest.css` | `colors` · `variants` · `data` | color tokens (default + 3 variants, light/dark, data arc) |
+| `layout.css` | `spacing` · `rounded` · `shapes` · `components` | spacing/shape tokens + component bindings |
+| `fonts.css` | `typography` | `@font-face` (WOFF2 + TTF fallback) + type tokens |
+| `theme.js` | — | no-build cycler: `resolveTheme`/`nextTheme`/`THEME_CYCLE` + `themechange` |
+| `a11y.css` | — | `.sr-only`, width-sizer, reduced-motion |
+| `theme-toggle.html` | — | toggle markup + `aria-live` status region |
+| `anti-fouc.html` | — | inline `<head>` guard snippet |
+| `ci-verify.example.yml` | — | **optional** CI recipe for the polyfetch verify gate |
+
+## Load order (no-build)
+
+```html
+<head>
+  <!-- 1. inline guard FIRST, before any stylesheet (paste anti-fouc.html) -->
+  <link rel="stylesheet" href="brand/ui-kit/eyerest.css">
+  <link rel="stylesheet" href="brand/ui-kit/fonts.css">
+  <link rel="stylesheet" href="brand/ui-kit/layout.css">
+  <link rel="stylesheet" href="brand/ui-kit/a11y.css">
+  <script type="module" src="brand/ui-kit/theme.js"></script>
+</head>
+```
+
+Place the `theme-toggle.html` markup in your toolbar; recolour charts on flip via
+`document.addEventListener('themechange', e => chart.update())`.
+
+## Fonts: WOFF2 for the web, TTF for baking
+
+`fonts.css` serves WOFF2 (with a TTF fallback) from `../fonts/`. The brand-baking pipeline
+(`../scripts/`) keeps the TTF/OTF because fonttools / cairosvg need desktop formats.
+`install_fonts.py` should emit both.
+
+## Verify with polyfetch — optional, recommended
+
+Check the rendered UI headlessly with the shared
+[`qte77/polyfetch-scrape`](https://github.com/qte77/polyfetch-scrape) stack — **check** that
+the EyeRest branding actually rendered (tokens, theme cycle, a11y, fonts, favicon) and
+**fetch** that URLs/assets return 200. Recommended before deploy; **not** a required gate.
+
+```bash
+# one-time browser install (shared, no per-repo dependency)
+uv run --directory ../polyfetch-scrape patchright install chromium
+
+# single-repo / in-project (point at your local/staging URL)
+uv run --directory ../polyfetch-scrape python ../qte77/brand/scripts/gui-check.py \
+  --url http://localhost:8137
+
+# cross-repo / multi-project drift sweep (audit live tokens vs DESIGN.md)
+uv run --directory ../polyfetch-scrape python ../qte77/brand/scripts/gui-check.py \
+  --urls urls.txt
+```
+
+`--directory` points at wherever the `polyfetch-scrape` checkout lives. See
+[`ci-verify.example.yml`](ci-verify.example.yml) to wire it into CI if/when you want it.

--- a/brand/ui-kit/a11y.css
+++ b/brand/ui-kit/a11y.css
@@ -1,0 +1,53 @@
+/*
+ * a11y.css — accessibility baseline for the qte77 theme control.
+ * Reference impl: analyze-stock-kpi (decision D3). Load after eyerest.css.
+ */
+
+/* Screen-reader-only: the live-region announce text is visually hidden but read aloud. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+/*
+ * Width-sizer: reserve the widest label ("System") so cycling System↔Light↔Dark never
+ * reflows the toolbar (no jitter). The invisible ::before sets the box width; the visible
+ * label sits in normal flow.
+ */
+#theme-toggle .theme-label {
+  display: inline-block;
+  text-align: left;
+}
+#theme-toggle .theme-label::before {
+  content: "System"; /* keep in sync with WIDEST_LABEL in theme.js */
+  display: block;
+  height: 0;
+  overflow: hidden;
+  visibility: hidden;
+}
+
+/* Visible focus — never rely on color alone. */
+#theme-toggle:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
+
+/* Honor reduced-motion globally (paperverse #77). */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/brand/ui-kit/anti-fouc.html
+++ b/brand/ui-kit/anti-fouc.html
@@ -1,0 +1,24 @@
+<!--
+  anti-fouc.html — inline theme guard. Paste this as the FIRST <script> in <head>,
+  before any stylesheet, so the scheme is applied before first paint (no flash).
+
+  Precedence: ?theme= › localStorage['qte77-theme'] › prefers-color-scheme.
+  Keep it inline and tiny — it must run synchronously, with no imports.
+  Mirror any change to STORAGE_KEY / mode set here and in ui-kit/theme.js.
+-->
+<script>
+  (function () {
+    try {
+      var modes = { system: 1, light: 1, dark: 1 };
+      var p = new URLSearchParams(location.search).get("theme");
+      var s = localStorage.getItem("qte77-theme");
+      var m = modes[p] ? p : modes[s] ? s : "system";
+      // explicit scheme → set attribute; system → leave unset (prefers-color-scheme governs)
+      if (m === "light" || m === "dark") {
+        document.documentElement.setAttribute("data-theme", m);
+      }
+    } catch (e) {
+      /* storage blocked — fall back to prefers-color-scheme, no attribute */
+    }
+  })();
+</script>

--- a/brand/ui-kit/ci-verify.example.yml
+++ b/brand/ui-kit/ci-verify.example.yml
@@ -1,0 +1,52 @@
+# OPTIONAL — polyfetch UI verify gate (check & fetch before users).
+#
+# This is an EXAMPLE, not wired by default. Polyfetch verification is opt-in: copy this to
+# a consuming project's .github/workflows/ only if you want the gate in CI. It is NOT
+# required to merge, and is NOT enabled for qte77/brand itself.
+#
+# It drives qte77/polyfetch-scrape's bundled Patchright to render the built UI and assert
+# the EyeRest branding (tokens, theme cycle, a11y, fonts, favicon) before deploy.
+
+name: ui-verify (optional)
+
+on:
+  workflow_dispatch:        # manual only by default; add push/pull_request to enforce
+  # push:
+  #   branches: [main]
+
+jobs:
+  gui-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # the shared verify stack — no per-repo browser dependency
+      - name: Checkout polyfetch-scrape
+        uses: actions/checkout@v4
+        with:
+          repository: qte77/polyfetch-scrape
+          path: polyfetch-scrape
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install browser
+        run: uv run --directory polyfetch-scrape patchright install --with-deps chromium
+
+      # serve the built UI (adjust to your build/serve step)
+      - name: Serve UI
+        run: |
+          python -m http.server 8137 --directory ui &
+          sleep 2
+
+      - name: gui-check (check + fetch)
+        run: |
+          uv run --directory polyfetch-scrape \
+            python brand/scripts/gui-check.py --url http://localhost:8137 --out gui-check-out
+
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gui-check-screenshots
+          path: gui-check-out/

--- a/brand/ui-kit/eyerest.css
+++ b/brand/ui-kit/eyerest.css
@@ -1,0 +1,101 @@
+/*
+ * eyerest.css — qte77 UI-branding COLOR tokens (EyeRest design system).
+ *
+ * GENERATED from ../DESIGN.md (front-matter `colors` / `variants` / `data`) — DO NOT
+ * HAND-EDIT. Source of truth: brand/DESIGN.md. Conformance is enforced by
+ * repo-baseline/tools/gui-check.py (token audit), not by editing this file.
+ *
+ * This file is COLOR only. Pair with layout.css (spacing/shape) and fonts.css (type).
+ *
+ * Cascade:
+ *   System  → no [data-theme] attribute; prefers-color-scheme governs.
+ *   Light/Dark → html[data-theme="light"|"dark"] forces the scheme.
+ *   Variant → html[data-variant="green"|"blublock"|"dusk"]; combine with data-theme.
+ * Never mix two variants in one view. Zero blue in any accent — the brand's core rule.
+ */
+
+/* ---------- Default (EyeRest flagship) — LIGHT ---------- */
+:root {
+  color-scheme: light dark;
+
+  --bg: #ece8d8;
+  --surface: #e2dec8;
+  --border: #c8c4b0;
+  --text: #2c2818;
+  --text-muted: #686040;
+  --primary: #7a6010;        /* deepened from EyeRest #8a7018 for WCAG AA on --primary-on */
+  --primary-on: #ece8d8;
+
+  /* zero-blue categorical data arc (charts, KPI heatmap) — LIGHT */
+  --data-positive: #4a6818;
+  --data-caution:  #787010;
+  --data-negative: #983828;
+  --data-alt:      #587818;
+}
+
+/* Default DARK — once for system-dark, once for the explicit attribute */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg: #1c1a14; --surface: #242018; --border: #383428;
+    --text: #d8d0b8; --text-muted: #a89878; --primary: #c8a858; --primary-on: #1c1a14;
+    --data-positive: #8aa860; --data-caution: #c8b868;
+    --data-negative: #c08060; --data-alt: #a8b870;
+  }
+}
+:root[data-theme="dark"] {
+  --bg: #1c1a14; --surface: #242018; --border: #383428;
+  --text: #d8d0b8; --text-muted: #a89878; --primary: #c8a858; --primary-on: #1c1a14;
+  --data-positive: #8aa860; --data-caution: #c8b868;
+  --data-negative: #c08060; --data-alt: #a8b870;
+}
+
+/* ---------- Variant: Green (forest / yellow-green) ---------- */
+:root[data-variant="green"] {
+  --bg: #f0f6ee; --surface: #e8f0e6; --border: #c0d4bc;
+  --text: #2a4a2a; --text-muted: #4a6a4a; --primary: #2a6a2a; --primary-on: #f0f6ee;
+}
+@media (prefers-color-scheme: dark) {
+  :root[data-variant="green"]:not([data-theme="light"]) {
+    --bg: #0c1610; --surface: #12201a; --border: #2a3e2c;
+    --text: #8cb888; --text-muted: #7aa878; --primary: #3a6a3a; --primary-on: #c4e8c0;
+  }
+}
+:root[data-variant="green"][data-theme="dark"] {
+  --bg: #0c1610; --surface: #12201a; --border: #2a3e2c;
+  --text: #8cb888; --text-muted: #7aa878; --primary: #3a6a3a; --primary-on: #c4e8c0;
+}
+
+/* ---------- Variant: BluBlock (zero-blue amber; blue-filter lenses) ---------- */
+:root[data-variant="blublock"] {
+  --bg: #f5ecd8; --surface: #ede3cc; --border: #c8b898;
+  --text: #3d2e18; --text-muted: #6b5838; --primary: #c06010; --primary-on: #f5ecd8;
+}
+@media (prefers-color-scheme: dark) {
+  :root[data-variant="blublock"]:not([data-theme="light"]) {
+    --bg: #1a1208; --surface: #231a0e; --border: #3d2e1a;
+    --text: #e8d5b0; --text-muted: #a08b6d; --primary: #e89030; --primary-on: #1a1208;
+  }
+}
+:root[data-variant="blublock"][data-theme="dark"] {
+  --bg: #1a1208; --surface: #231a0e; --border: #3d2e1a;
+  --text: #e8d5b0; --text-muted: #a08b6d; --primary: #e89030; --primary-on: #1a1208;
+}
+
+/* ---------- Variant: Dusk (plum-gray / sage, earth tones) ---------- */
+:root[data-variant="dusk"] {
+  --bg: #eaece2; --surface: #e0e3d7; --border: #c8cac0;
+  --text: #2c2622; --text-muted: #6a6058; --primary: #7a5820; --primary-on: #eaece2;
+}
+@media (prefers-color-scheme: dark) {
+  :root[data-variant="dusk"]:not([data-theme="light"]) {
+    --bg: #1f1b22; --surface: #2a2630; --border: #3a343e;
+    --text: #d8ccbc; --text-muted: #b0a498; --primary: #c8a468; --primary-on: #1f1b22;
+  }
+}
+:root[data-variant="dusk"][data-theme="dark"] {
+  --bg: #1f1b22; --surface: #2a2630; --border: #3a343e;
+  --text: #d8ccbc; --text-muted: #b0a498; --primary: #c8a468; --primary-on: #1f1b22;
+}
+
+/* ---------- Base color application ---------- */
+body { background: var(--bg); color: var(--text); }

--- a/brand/ui-kit/fonts.css
+++ b/brand/ui-kit/fonts.css
@@ -1,0 +1,73 @@
+/*
+ * fonts.css — qte77 UI-branding TYPOGRAPHY (EyeRest).
+ *
+ * GENERATED from ../DESIGN.md (`typography`) — DO NOT HAND-EDIT. Source of truth:
+ * brand/DESIGN.md. Pair with eyerest.css (color) and layout.css (spacing/shape).
+ *
+ * Web delivery prefers WOFF2 (Brotli-compressed, universal since ~2018) with a TTF
+ * fallback, so it works against today's ../fonts/*.ttf and upgrades to *.woff2 once
+ * install_fonts.py emits them. The brand-baking pipeline (../scripts/) keeps TTF/OTF —
+ * fonttools / cairosvg need desktop formats.
+ *
+ * Licenses: Inter + JetBrains Mono are SIL OFL 1.1 (see ../fonts/LICENSES/).
+ */
+
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url("../fonts/Inter-Regular.woff2") format("woff2"),
+       url("../fonts/Inter-Regular.ttf") format("truetype");
+}
+@font-face {
+  font-family: "Inter";
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url("../fonts/Inter-Bold.woff2") format("woff2"),
+       url("../fonts/Inter-Bold.ttf") format("truetype");
+}
+@font-face {
+  font-family: "JetBrains Mono";
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  src: url("../fonts/JetBrainsMono-Regular.woff2") format("woff2"),
+       url("../fonts/JetBrainsMono-Regular.ttf") format("truetype");
+}
+@font-face {
+  font-family: "JetBrains Mono";
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+  src: url("../fonts/JetBrainsMono-Bold.woff2") format("woff2"),
+       url("../fonts/JetBrainsMono-Bold.ttf") format("truetype");
+}
+
+:root {
+  /* fallbacks resolve before the web font loads (font-display: swap) */
+  --font-sans: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", monospace;
+  --text-base: 16px;
+  --leading: 1.6;
+  --text-mono: 14px;
+  --leading-mono: 1.5;
+}
+
+/* ---------- Base type application ---------- */
+body {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: var(--leading);
+}
+h1 { font-size: 30px; line-height: 1.25; font-weight: 600; }
+h2 { font-size: 24px; line-height: 1.3;  font-weight: 600; }
+h3 { font-size: 20px; line-height: 1.4;  font-weight: 600; }
+code, kbd, samp, pre {
+  font-family: var(--font-mono);
+  font-size: var(--text-mono);
+  line-height: var(--leading-mono);
+}
+/* numeric data is tabular mono */
+.num, [data-numeric] { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }

--- a/brand/ui-kit/layout.css
+++ b/brand/ui-kit/layout.css
@@ -1,0 +1,56 @@
+/*
+ * layout.css — qte77 UI-branding LAYOUT (EyeRest): spacing, shape, components.
+ *
+ * GENERATED from ../DESIGN.md (`spacing` / `rounded` / `layout` / `shapes` /
+ * `components`) — DO NOT HAND-EDIT. Source of truth: brand/DESIGN.md.
+ * Pair with eyerest.css (color) and fonts.css (type). Colors are referenced via tokens
+ * only — never a raw hex here.
+ */
+
+:root {
+  --space-unit: 8px;     /* keep the 8px rhythm even full-bleed */
+  --container: 768px;    /* prose max-width / mobile breakpoint */
+  --radius-sm: 4px;      /* inputs, chips */
+  --radius-md: 6px;      /* buttons, cells */
+  --radius-lg: 12px;     /* cards, panels */
+}
+
+/* Single-column, content-first. Dashboards may go full-bleed but keep the rhythm. */
+.container {
+  max-width: var(--container);
+  margin-inline: auto;
+  padding-inline: calc(2 * var(--space-unit));
+}
+
+/* ---------- Components (compose tokens; recolour wholesale on theme/variant flip) ---------- */
+.btn-primary {
+  background: var(--primary);
+  color: var(--primary-on);
+  border: 0;
+  border-radius: var(--radius-md);
+  padding: 6px 16px;
+  font: inherit;
+  cursor: pointer;
+}
+.card {
+  background: var(--surface);
+  color: var(--text);
+  border-radius: var(--radius-lg);
+  padding: calc(2 * var(--space-unit));
+}
+.input {
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 6px 12px;
+}
+code, kbd, samp, pre {
+  background: var(--surface);
+  border-radius: var(--radius-sm);
+}
+.caption { color: var(--text-muted); }
+.divider { background: var(--border); height: 1px; border: 0; }
+/* Soft, not round. No pills except removable filter chips. */
+.chip { border-radius: var(--radius-sm); }
+.chip--removable { border-radius: 999px; }

--- a/brand/ui-kit/theme-toggle.html
+++ b/brand/ui-kit/theme-toggle.html
@@ -1,0 +1,21 @@
+<!--
+  theme-toggle.html — the single cycling theme control + its live region.
+  Drop into your toolbar/header. Wired by ui-kit/theme.js; styled by ui-kit/a11y.css.
+
+  - One button cycles system → light → dark (decision D2 glyphs ◐ ○ ●).
+  - aria-label/title are set dynamically by theme.js ("Color theme: <Mode> (click to change)").
+  - #theme-status is the polite live region announced on every change (a11y, decision D3).
+  - The glyph is aria-hidden (decorative); the label carries the meaning.
+  Initial values below assume System; theme.js overwrites them on load.
+-->
+<button
+  id="theme-toggle"
+  type="button"
+  aria-label="Color theme: System (click to change)"
+  title="Color theme: System (click to change)"
+>
+  <span class="theme-glyph" aria-hidden="true">◐</span>
+  <span class="theme-label">System</span>
+</button>
+
+<span id="theme-status" class="sr-only" role="status" aria-live="polite"></span>

--- a/brand/ui-kit/theme.js
+++ b/brand/ui-kit/theme.js
@@ -1,0 +1,142 @@
+// theme.js — qte77 shared theme cycler (no-build ES module).
+//
+// Works with plain `<script type="module">` — no bundler (agentic-kit constraint).
+// Pure logic (resolveTheme / nextTheme / isThemeMode / THEME_CYCLE) is DOM-free and
+// unit-testable; DOM glue is in initThemeToggle(). Reference impl: analyze-stock-kpi.
+//
+// Pair with: ui-kit/anti-fouc.html (inline <head> guard), ui-kit/theme-toggle.html
+// (markup), ui-kit/a11y.css (.sr-only + width-sizer), ui-kit/eyerest.css (tokens).
+
+export const THEME_CYCLE = ["system", "light", "dark"];
+export const STORAGE_KEY = "qte77-theme"; // standardized (decision D4)
+
+// glyph + label per mode (decision D2: ◐ ○ ●)
+export const THEME_META = {
+  system: { glyph: "◐", label: "System" },
+  light: { glyph: "○", label: "Light" },
+  dark: { glyph: "●", label: "Dark" },
+};
+
+// widest label — used by a11y.css width-sizer; kept here as the single source.
+export const WIDEST_LABEL = "System";
+
+/** @returns {boolean} whether `v` is one of system|light|dark */
+export function isThemeMode(v) {
+  return THEME_CYCLE.includes(v);
+}
+
+/**
+ * Resolve the active mode by precedence: ?theme= › localStorage › "system".
+ * Pure — pass the two raw strings in; no DOM/storage access here.
+ */
+export function resolveTheme(urlValue, lsValue) {
+  if (isThemeMode(urlValue)) return urlValue;
+  if (isThemeMode(lsValue)) return lsValue;
+  return "system";
+}
+
+/** Next mode in the cycle (wraps). */
+export function nextTheme(mode) {
+  const i = THEME_CYCLE.indexOf(mode);
+  return THEME_CYCLE[(i + 1) % THEME_CYCLE.length];
+}
+
+/** Effective light|dark for a mode (resolves "system" against the OS preference). */
+export function effectiveTheme(mode) {
+  if (mode === "light" || mode === "dark") return mode;
+  const dark =
+    typeof window !== "undefined" &&
+    window.matchMedia &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches;
+  return dark ? "dark" : "light";
+}
+
+/**
+ * Apply a mode to the document: set/remove html[data-theme], persist, update the
+ * toggle's accessible name + label, announce via the live region, and emit
+ * `themechange` (so charts/canvases recolour). Returns the applied mode.
+ */
+export function applyTheme(mode, { persist = true } = {}) {
+  const root = document.documentElement;
+  if (mode === "light" || mode === "dark") {
+    root.setAttribute("data-theme", mode); // explicit scheme
+  } else {
+    root.removeAttribute("data-theme"); // system → prefers-color-scheme governs
+  }
+  if (persist) {
+    try {
+      localStorage.setItem(STORAGE_KEY, mode);
+    } catch (_) {
+      /* private mode / storage disabled — non-fatal */
+    }
+  }
+
+  const meta = THEME_META[mode];
+  const name = `Color theme: ${meta.label} (click to change)`;
+
+  const btn = document.getElementById("theme-toggle");
+  if (btn) {
+    btn.setAttribute("aria-label", name);
+    btn.setAttribute("title", name);
+    const g = btn.querySelector(".theme-glyph");
+    const l = btn.querySelector(".theme-label");
+    if (g) g.textContent = meta.glyph;
+    if (l) l.textContent = meta.label;
+  }
+
+  const status = document.getElementById("theme-status");
+  if (status) status.textContent = `Theme: ${meta.label}`;
+
+  const effective = effectiveTheme(mode);
+  document.dispatchEvent(
+    new CustomEvent("themechange", { detail: { mode, effective } }),
+  );
+  return mode;
+}
+
+/**
+ * Wire up the #theme-toggle button and initial state.
+ * Reads ?theme= and localStorage, applies, and:
+ *  - cycles on click;
+ *  - in System mode, re-applies when the OS preference flips (keeps charts in sync);
+ *  - supports keyboard Escape to blur (panel-close hook left to the app).
+ */
+export function initThemeToggle() {
+  const url = new URLSearchParams(location.search).get("theme");
+  let ls = null;
+  try {
+    ls = localStorage.getItem(STORAGE_KEY);
+  } catch (_) {
+    /* ignore */
+  }
+  let mode = resolveTheme(url, ls);
+  // don't persist a URL-driven choice over the stored one unless it's already stored
+  applyTheme(mode, { persist: isThemeMode(ls) || isThemeMode(url) });
+
+  const btn = document.getElementById("theme-toggle");
+  if (btn) {
+    btn.addEventListener("click", () => {
+      mode = nextTheme(mode);
+      applyTheme(mode);
+    });
+  }
+
+  if (window.matchMedia) {
+    window
+      .matchMedia("(prefers-color-scheme: dark)")
+      .addEventListener("change", () => {
+        if (mode === "system") applyTheme("system"); // re-emit themechange
+      });
+  }
+}
+
+// Auto-init when imported directly by a page (no-build friendly). Apps that want to
+// control timing can import the functions and skip this by loading as a module that
+// only re-exports.
+if (typeof document !== "undefined") {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initThemeToggle, { once: true });
+  } else {
+    initThemeToggle();
+  }
+}


### PR DESCRIPTION
## What

Consolidates the qte77 GUI-unification findings into `brand/`: the shared **EyeRest ui-kit**
(no-build), the OG/figure renderer, an **optional** polyfetch verifier, and a consolidated
findings doc with an actionable roadmap.

## Added

- `brand/ui-kit/` — color (`eyerest.css`) / layout (`layout.css`) / fonts (`fonts.css`),
  the no-build theme cycler (`theme.js`), a11y (`a11y.css`), toggle + anti-FOUC snippets,
  README, and an **optional** CI recipe (`ci-verify.example.yml`).
- `brand/scripts/render_og.py` — UI OG/figure cards (cairosvg, EyeRest, 1200x630).
- `brand/scripts/gui-check.py` — **optional** check-and-fetch UI verifier over
  `polyfetch-scrape` (dual-scope: in-project + cross-repo drift). Not a required CI gate.
- `brand/ui-kit/BASELINE.md` — consolidated findings (GitHub-vs-UI branding split,
  decisions D1-D10, gotchas) + actionable roadmap.

## Notes

- Tokens have one source of truth: `brand/DESIGN.md`. The CSS is generated from it
  (faithful hand-render for now; a `make ui-kit` generator is a roadmap item).
- Fonts: WOFF2 for web (TTF fallback), TTF kept for the baking pipeline.
- Polyfetch verification is **optional** — documented via `uv run --directory`, opt-in CI.
- GitHub branding (`brand/images/`) stays Primer-blue; UI branding (`brand/ui-kit/`) is
  zero-blue EyeRest.

## Roadmap (in BASELINE.md)

`make ui-kit` generator, `install_fonts.py` WOFF2, favicon decision (D7), promote
`gui-check.py` to `repo-baseline/tools/`, adopt on `analyze-stock-kpi` first, update
issues #111/#112.

Generated with Claude <noreply@anthropic.com>
