### PR TITLE
docs(brand): resolve favicon + site logo to brand/images/logo-mark (D7)

### DIFF
--- a/brand/ui-kit/BASELINE.md
+++ b/brand/ui-kit/BASELINE.md
@@ -52,7 +52,7 @@ without a bundler.
 | D4 | `localStorage` key = `qte77-theme` | standardize the divergent keys |
 | D5 | Tokens have one source of truth = `DESIGN.md` | CSS is generated; no second tokens source |
 | D6 | Home = `brand/ui-kit/` (next to `DESIGN.md`) | tightest DRY; no new repo, no cross-repo token hop |
-| D7 | Favicon = open decision (recommend EyeRest-tinted mark) | keeps the UI zero-blue; GitHub avatar stays Primer-blue |
+| D7 | Favicon **+ site logo** = `brand/images/logo-mark.paths.dejavu.svg` | one path-baked brand asset for both; sourced from brand/images |
 | D8 | OG cards split by branding | 1200×630 figure cards (UI) vs 1280×640 repo social (GitHub) |
 | D9 | Default CSS split into color / layout / fonts | matches `DESIGN.md` sections; pull only what you need |
 | D10 | Fonts: WOFF2 for web, TTF kept for baking | smallest web payload; cairosvg/fonttools need desktop formats |
@@ -107,7 +107,7 @@ uv run --directory ../polyfetch-scrape python brand/scripts/gui-check.py --urls 
 - [ ] Add a `make ui-kit` target that **generates** `eyerest.css` / `layout.css` /
       `fonts.css` from `DESIGN.md` (keep them in sync; today they are faithful hand-renders).
 - [ ] Update `scripts/install_fonts.py` to emit **WOFF2** (web) alongside TTF (baking).
-- [ ] Decide the favicon (D7): EyeRest-tinted mark variant vs. reuse the Primer-blue mark.
+- [x] Favicon (D7) — resolved: favicon + site logo = `brand/images/logo-mark.paths.dejavu.svg` (see README).
 - [ ] Promote `scripts/gui-check.py` to `repo-baseline/tools/` for the cross-repo drift
       sweep (the org-wide baseline/drift home); keep the brand copy or symlink.
 - [ ] Wire the existing GUIs onto the kit (start with `analyze-stock-kpi`, the reference).

--- a/brand/ui-kit/README.md
+++ b/brand/ui-kit/README.md
@@ -44,6 +44,26 @@ Place the `theme-toggle.html` markup in your toolbar; recolour charts on flip vi
 (`../scripts/`) keeps the TTF/OTF because fonttools / cairosvg need desktop formats.
 `install_fonts.py` should emit both.
 
+## Favicon & logo
+
+Both come from `brand/images/` (single source) — the same path-baked mark (resolves D7):
+
+- **Favicon + site logo** = `brand/images/logo-mark.paths.dejavu.svg` (path-baked square
+  mark; renders identically, no font dependency).
+- These are **GitHub-native brand** assets used on UI surfaces for identity — only the
+  *theme* (colors/fonts) is EyeRest.
+
+Vendor the file into your site's `assets/` (same as fonts — a deployed site can't reference
+another repo at runtime), then:
+
+```html
+<link rel="icon" type="image/svg+xml" href="/assets/logo-mark.svg">
+<img class="site-logo" src="/assets/logo-mark.svg" alt="qte77">
+```
+
+For **`og:image`** use a raster (e.g. `brand/images/avatar_neutral.dejavu.png` or a
+`render_og.py` card) — many platforms don't render SVG OG images.
+
 ## Verify with polyfetch — optional, recommended
 
 Check the rendered UI headlessly with the shared


### PR DESCRIPTION
## What

Resolves **D7** (favicon decision) for `brand/ui-kit/`: both the **favicon** and the
**site logo** use a single path-baked brand asset — `brand/images/logo-mark.paths.dejavu.svg`.

- `BASELINE.md` — D7 row + actionable item updated to resolved.
- `README.md` — new "Favicon & logo" section with the adopter `<head>` snippet, the
  vendoring note (deployed sites can't reference another repo at runtime), and an
  `og:image` raster tip.

These are GitHub-native brand assets used on UI surfaces for identity; only the theme
(colors/fonts) is EyeRest.

Generated with Claude <noreply@anthropic.com>
