### PR TITLE
docs(brand): streamline ui-kit docs — one owner per topic, drop duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `brand/ui-kit/` docs streamlined to one-owner-per-topic — `README.md` = usage (front door), `BASELINE.md` = rationale/decisions/roadmap, `DISCOVERABILITY.md` = SEO/GEO/ASO; removed the duplicated verify commands + per-file token re-listing from `BASELINE.md`; added a doc map to `README.md` (PR #117)
 - Profile `README.md`: wordmark centered horizontally via `<p align="center">`, updated to `brand/images/` paths (PR #47)
 - `brand/README.md`, `docs/github-image-theming.md`: live-example paths updated to `brand/images/` (PR #47)
 - `brand/scripts/render_avatar.py`: `BRAND` constant + `IMAGES` resolve to subfolder (PR #47)

--- a/brand/ui-kit/BASELINE.md
+++ b/brand/ui-kit/BASELINE.md
@@ -2,8 +2,8 @@
 
 Consolidated from a review of four qte77 GUIs (qte77.github.io, paperverse,
 analyze-stock-kpi, agentic-job-offer-to-application-kit) and how each verified its UI with
-`polyfetch-scrape`. This is the rationale behind [`brand/ui-kit/`](README.md): the shared,
-no-build EyeRest theming used by every qte77-branded UI.
+`polyfetch-scrape`. **Start at [`README.md`](README.md) to *use* the kit; this doc is the
+*why*** — the findings, decisions, and roadmap behind the shared no-build EyeRest theming.
 
 ## Two brandings — GitHub vs UI
 
@@ -59,38 +59,21 @@ without a bundler.
 
 ## Tokens & CSS
 
-`DESIGN.md` is the single source of truth (D5). The CSS is generated from it and split (D9):
+`DESIGN.md` is the single source of truth (D5); the CSS is **generated** from it and split
+into color / layout / fonts (D9) — see [`README.md`](README.md) for the per-file contents.
+Everything references tokens, never a raw hex; `--primary` is the deepened `#7a6010` /
+`#c8a858` (WCAG AA on `--primary-on`).
 
-- [`eyerest.css`](eyerest.css) — color: default + 3 variants (Green/BluBlock/Dusk),
-  light/dark, zero-blue data arc. Selected via `html[data-variant="…"]`.
-- [`layout.css`](layout.css) — spacing (8px unit), radii (4/6/12px), container (768px),
-  component bindings.
-- [`fonts.css`](fonts.css) — `@font-face` (WOFF2 + TTF fallback), Inter + JetBrains Mono.
+## Verify with polyfetch — optional
 
-All reference tokens — never a raw hex. `--primary` is the deepened `#7a6010` / `#c8a858`
-(WCAG AA on `--primary-on`).
+The recommended (not required) way to catch branding/render defects **before users**:
+[`../scripts/gui-check.py`](../scripts/gui-check.py) drives the shared `polyfetch-scrape`
+stack to **check** the rendered UI (tokens, theme cycle, a11y, fonts, favicon, WebGL) and
+**fetch** that URLs/assets return 200. It is **dual-scope** — *in-project* (your local/
+staging URL) and *cross-repo* (sweep deployed URLs, audit live tokens vs `DESIGN.md` for
+drift).
 
-## Verify with polyfetch — optional, recommended
-
-Every qte77-branded UI can **check & fetch its UI headlessly, early, before users** with the
-shared [`qte77/polyfetch-scrape`](https://github.com/qte77/polyfetch-scrape) stack. It is the
-recommended way to catch branding/render defects pre-deploy — **optional, not a required CI
-gate** (see [`ci-verify.example.yml`](ci-verify.example.yml) for opt-in CI).
-
-[`../scripts/gui-check.py`](../scripts/gui-check.py) is dual-scope:
-
-- **single-repo / in-project** — render your local/staging URL and assert EyeRest tokens,
-  theme cycle, a11y, fonts, favicon, WebGL.
-- **cross-repo / multi-project** — sweep deployed URLs and audit live computed tokens
-  against `DESIGN.md` (drift detection).
-
-```bash
-uv run --directory ../polyfetch-scrape patchright install chromium          # once
-uv run --directory ../polyfetch-scrape python brand/scripts/gui-check.py --url http://localhost:8137
-uv run --directory ../polyfetch-scrape python brand/scripts/gui-check.py --urls urls.txt
-```
-
-`--directory` points at wherever the `polyfetch-scrape` checkout lives.
+Commands + the opt-in CI recipe live in [`README.md`](README.md) ("Verify with polyfetch").
 
 ## Portable gotchas
 
@@ -111,7 +94,8 @@ uv run --directory ../polyfetch-scrape python brand/scripts/gui-check.py --urls 
 - [ ] Promote `scripts/gui-check.py` to `repo-baseline/tools/` for the cross-repo drift
       sweep (the org-wide baseline/drift home); keep the brand copy or symlink.
 - [ ] Wire the existing GUIs onto the kit (start with `analyze-stock-kpi`, the reference).
-- [ ] Update issues #111 (shared ui-kit) and #112 (SVG/diagram pipeline) with this placement.
+- [x] Update issues #111 (shared ui-kit) and #112 (SVG/diagram pipeline) — done.
+- [ ] Discoverability (SEO / GEO / ASO) — see [`DISCOVERABILITY.md`](DISCOVERABILITY.md) for the SEO head partial + GEO/ASO convention items.
 - [ ] (optional) Adopt `ci-verify.example.yml` in projects that want the gate in CI.
 
 ## Discoverability (SEO / GEO / ASO)

--- a/brand/ui-kit/DISCOVERABILITY.md
+++ b/brand/ui-kit/DISCOVERABILITY.md
@@ -52,6 +52,8 @@ Optimizing so autonomous agents can **find, parse, and act**:
 
 ## Roadmap
 
+Part of the master roadmap in [`BASELINE.md`](BASELINE.md) — this is the SEO/GEO/ASO subset.
+
 - [ ] **SEO head partial** — `brand/ui-kit/seo.html` (meta + canonical + OG / Twitter +
       JSON-LD; `og:image` ← `render_og.py`).
 - [ ] **Machine-readability convention (GEO + ASO)** — standardize `llms.txt`

--- a/brand/ui-kit/README.md
+++ b/brand/ui-kit/README.md
@@ -9,6 +9,13 @@ rationale and decisions.
 > **Provenance.** `eyerest.css`, `layout.css`, and `fonts.css` are **generated from
 > `../DESIGN.md`** — do not hand-edit. The token source of truth is `DESIGN.md`.
 
+## Docs in this kit
+
+- **`README.md`** (you are here) — how to adopt & use the kit.
+- [`BASELINE.md`](BASELINE.md) — the *why*: branding split, decisions (D1–D10), gotchas, roadmap.
+- [`DISCOVERABILITY.md`](DISCOVERABILITY.md) — SEO / GEO / ASO.
+- [`../DESIGN.md`](../DESIGN.md) — token source of truth.
+
 ## Contents
 
 | File | From `DESIGN.md` | What |


### PR DESCRIPTION
## What

Streamlines `brand/ui-kit/` docs to **one owner per topic** (no functional change):

- **`README.md`** = the front door / *how to use* (contents, load order, fonts vendoring,
  favicon snippet, verify commands) + a new **doc map**.
- **`BASELINE.md`** = the *why* (branding split, decisions D1–D10, gotchas, **master
  roadmap**). Removed the **duplicated verify command block** (→ links README) and the
  **per-file token re-listing** (→ links README / DESIGN).
- **`DISCOVERABILITY.md`** = SEO / GEO / ASO; its roadmap now notes it's the subset of the
  master roadmap in `BASELINE.md`.

Also marks the #111/#112 update as done in the roadmap, and logs the change in `CHANGELOG.md`.

Net −6 lines; each topic now has a single home with the others linking to it.

Generated with Claude <noreply@anthropic.com>
