### PR TITLE
docs(brand): add self-hosting (no CDN) advice for fonts + external libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `brand/ui-kit/README.md` "Self-hosting (no CDN)": advice to vendor fonts + external JS libs (Chart.js / Fuse.js) into the repo and pin exact versions — privacy, reliability/offline, simpler CSP, supply-chain control, GitHub-Pages portability (PR #119)
 - `brand/scripts/gen_ui_kit.py` + `make -C brand ui_kit`: generate `brand/ui-kit/eyerest.css` (color tokens) from `DESIGN.md` so the two never drift (decision D5); `--check` flags staleness (PR #118)
 - `brand/DESIGN.md`: machine-readable `data-dark` block (was YAML comments only) so the dark data arc is generatable (PR #118)
 - WOFF2 web fonts in `brand/scripts/install_fonts.py` (Inter + JetBrains Mono 400/700 from Fontsource); `fonts.css` prefers WOFF2 with TTF fallback (PR #118)

--- a/brand/ui-kit/README.md
+++ b/brand/ui-kit/README.md
@@ -51,6 +51,21 @@ Place the `theme-toggle.html` markup in your toolbar; recolour charts on flip vi
 (`../scripts/`) keeps the TTF/OTF because fonttools / cairosvg need desktop formats.
 `install_fonts.py` should emit both.
 
+## Self-hosting (no CDN)
+
+Vendor everything the GUI needs — fonts (above) and any external JS libs (Chart.js, Fuse.js,
+…) — into the repo and serve it from your own origin. Don't hotlink a CDN.
+
+**Why:** no third-party requests (privacy), works offline / survives CDN outages, a simpler
+Content-Security-Policy, supply-chain control, and clean GitHub-Pages portability.
+
+**How:**
+
+- **Fonts** → `../fonts/` via `install_fonts.py` + `fonts.css` (see above).
+- **Libs** → a committed `vendor/` dir (e.g. `ui/public/vendor/chart.umd.min.js`); load via a
+  plain `<script>` tag — no bundler needed. **Pin the exact version** in the file/commit;
+  never track `@latest`.
+
 ## Favicon & logo
 
 Both come from `brand/images/` (single source) — the same path-baked mark (resolves D7):


### PR DESCRIPTION
Adds a short **Self-hosting (no CDN)** section to `brand/ui-kit/README.md`: vendor fonts (already covered) + external JS libs (Chart.js/Fuse.js) into the repo, load via plain `<script>`, pin exact versions. Why: privacy, reliability/offline, simpler CSP, supply-chain control, GitHub-Pages portability. DRY — the fonts half links the existing Fonts section.

Generated with Claude <noreply@anthropic.com>