### PR TITLE
feat(brand): add portable SEO head partial (seo.js + seo.html)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `brand/ui-kit/seo.js` + `seo.html`: portable SEO head — meta + Open Graph + Twitter Card + JSON-LD (`BlogPosting`/`WebSite`), framework-free parity with the Jekyll sites; the JSON-LD also feeds GEO/ASO (PR #120)
 - `brand/ui-kit/README.md` "Self-hosting (no CDN)": advice to vendor fonts + external JS libs (Chart.js / Fuse.js) into the repo and pin exact versions — privacy, reliability/offline, simpler CSP, supply-chain control, GitHub-Pages portability (PR #119)
 - `brand/scripts/gen_ui_kit.py` + `make -C brand ui_kit`: generate `brand/ui-kit/eyerest.css` (color tokens) from `DESIGN.md` so the two never drift (decision D5); `--check` flags staleness (PR #118)
 - `brand/DESIGN.md`: machine-readable `data-dark` block (was YAML comments only) so the dark data arc is generatable (PR #118)

--- a/brand/ui-kit/DISCOVERABILITY.md
+++ b/brand/ui-kit/DISCOVERABILITY.md
@@ -22,10 +22,10 @@ and GEO + ASO overlap enough to share one convention.
 - **social cards** — favicon / logo + `og:image` +
   [`../scripts/render_og.py`](../scripts/render_og.py) cover the OG sliver of SEO.
 
-## SEO — head partial (planned unit)
+## SEO — head partial (shipped)
 
-A no-build `seo.html` head partial (portable across no-build / Vite / Jekyll; replaces the
-Jekyll-only `jekyll-seo-tag` path for non-Jekyll sites):
+[`seo.html`](seo.html) (authored template) + [`seo.js`](seo.js) (`renderHead(cfg)` build-time
+builder) give portable head parity with the Jekyll sites, framework-free:
 
 - `<title>` + `<meta name="description">` + `<link rel="canonical">`
 - Open Graph + Twitter Card (`og:title/description/image/url`, `twitter:card`)
@@ -54,8 +54,8 @@ Optimizing so autonomous agents can **find, parse, and act**:
 
 Part of the master roadmap in [`BASELINE.md`](BASELINE.md) — this is the SEO/GEO/ASO subset.
 
-- [ ] **SEO head partial** — `brand/ui-kit/seo.html` (meta + canonical + OG / Twitter +
-      JSON-LD; `og:image` ← `render_og.py`).
+- [x] **SEO head partial** — shipped: `seo.js` (builder) + `seo.html` (template); meta +
+      canonical + OG / Twitter + JSON-LD (`BlogPosting`/`WebSite`).
 - [ ] **Machine-readability convention (GEO + ASO)** — standardize `llms.txt`
       (`gha-llms-txt-action`) + JSON-LD + semantic / ARIA + stable selectors so answer-engines
       and autonomous agents parse the sites consistently.

--- a/brand/ui-kit/README.md
+++ b/brand/ui-kit/README.md
@@ -28,6 +28,7 @@ rationale and decisions.
 | `theme-toggle.html` | — | toggle markup + `aria-live` status region |
 | `anti-fouc.html` | — | inline `<head>` guard snippet |
 | `ci-verify.example.yml` | — | **optional** CI recipe for the polyfetch verify gate |
+| `seo.js` / `seo.html` | — | portable SEO head — meta + OG/Twitter + JSON-LD (builder + template) |
 
 ## Load order (no-build)
 
@@ -85,6 +86,19 @@ another repo at runtime), then:
 
 For **`og:image`** use a raster (e.g. `brand/images/avatar_neutral.dejavu.png` or a
 `render_og.py` card) — many platforms don't render SVG OG images.
+
+## SEO
+
+Portable SEO `<head>` parity with the Jekyll sites, framework-free (for the no-build / Vite
+GUIs). Two options:
+
+- **Author** [`seo.html`](seo.html) — copy into your `<head>`, fill the `{{PLACEHOLDERS}}`;
+  meta lives in the served HTML (best for crawlers, no JS needed).
+- **Generate** with [`seo.js`](seo.js) — `renderHead(cfg)` emits the same tags at build time
+  and keeps the JSON-LD in sync (`BlogPosting` for posts, `WebSite` otherwise).
+
+`og:image` should be a raster (a `render_og.py` card or `brand/images/avatar_*.png`). The
+JSON-LD also feeds GEO / ASO — see [`DISCOVERABILITY.md`](DISCOVERABILITY.md).
 
 ## Verify with polyfetch — optional, recommended
 

--- a/brand/ui-kit/seo.html
+++ b/brand/ui-kit/seo.html
@@ -1,0 +1,50 @@
+<!--
+  seo.html — authored SEO head template (framework-free).
+
+  Two ways to use it:
+  1. Author it directly: copy into your <head>, replace the {{PLACEHOLDERS}} (by
+     hand, Vite env, or your templating). Best for SEO — meta is in the served HTML,
+     no JS required.
+  2. Generate it: run seo.js at build time — `renderHead(cfg)` emits exactly these
+     tags (and keeps the JSON-LD in sync). See seo.js.
+
+  og:image / twitter:image should be a RASTER (e.g. a render_og.py card or
+  brand/images/avatar_neutral.dejavu.png) — many platforms don't render SVG OG images.
+-->
+<title>{{TITLE}} | {{SITE_NAME}}</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<meta name="description" content="{{DESCRIPTION}}" />
+<meta name="author" content="{{AUTHOR}}" />
+<meta name="keywords" content="{{KEYWORDS}}" />
+<meta name="robots" content="index, follow" />
+<link rel="canonical" href="{{URL}}" />
+
+<!-- Open Graph -->
+<meta property="og:title" content="{{TITLE}}" />
+<meta property="og:description" content="{{DESCRIPTION}}" />
+<meta property="og:url" content="{{URL}}" />
+<meta property="og:site_name" content="{{SITE_NAME}}" />
+<meta property="og:type" content="website" /><!-- "article" for posts -->
+<meta property="og:locale" content="en_US" />
+<meta property="og:image" content="{{IMAGE}}" />
+
+<!-- Twitter Card -->
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="@{{TWITTER}}" />
+<meta name="twitter:creator" content="@{{TWITTER}}" />
+<meta name="twitter:title" content="{{TITLE}}" />
+<meta name="twitter:description" content="{{DESCRIPTION}}" />
+<meta name="twitter:image" content="{{IMAGE}}" />
+
+<!-- JSON-LD (WebSite; use BlogPosting for posts — seo.js switches automatically).
+     Also feeds GEO / ASO; see DISCOVERABILITY.md. -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "{{SITE_NAME}}",
+  "url": "{{SITE_URL}}",
+  "description": "{{DESCRIPTION}}",
+  "author": { "@type": "Person", "name": "{{AUTHOR}}", "url": "{{SITE_URL}}" }
+}
+</script>

--- a/brand/ui-kit/seo.js
+++ b/brand/ui-kit/seo.js
@@ -1,0 +1,117 @@
+// seo.js — qte77 portable SEO head builder (no-build ES module).
+//
+// Emits the same head tags a Jekyll `jekyll-seo-tag` site produces (meta +
+// Open Graph + Twitter Card + JSON-LD), but framework-free — so the no-build /
+// Vite GUIs get parity with qte77.github.io. Intended as a BUILD-TIME helper
+// (run under Node to emit static `<head>` HTML), not a runtime injector —
+// crawlers shouldn't depend on JS to see your meta. See seo.html for the
+// authored-template alternative.
+//
+// The JSON-LD also feeds GEO + ASO (see DISCOVERABILITY.md).
+
+/** Escape a string for safe use inside an HTML double-quoted attribute. */
+export function esc(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+const isArticle = (cfg) => cfg.type === "article" || cfg.type === "post";
+
+/**
+ * Build the schema.org JSON-LD object: `BlogPosting` for an article, else a
+ * `WebSite` with an `author` Person. Pure — returns a plain object.
+ */
+export function buildJsonLd(cfg) {
+  const author = {
+    "@type": "Person",
+    name: cfg.author?.name,
+    url: cfg.author?.url || cfg.siteUrl,
+  };
+  if (cfg.author?.sameAs?.length) author.sameAs = cfg.author.sameAs;
+  if (cfg.author?.image) {
+    author.image = { "@type": "ImageObject", url: cfg.author.image };
+  }
+
+  if (!isArticle(cfg)) {
+    return {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      name: cfg.siteName || cfg.title,
+      url: cfg.siteUrl || cfg.url,
+      description: cfg.description,
+      author,
+    };
+  }
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    mainEntityOfPage: { "@type": "WebPage", "@id": cfg.url },
+    headline: cfg.title,
+    description: cfg.description,
+    image: cfg.image || cfg.siteImage,
+    datePublished: cfg.datePublished,
+    dateModified: cfg.dateModified || cfg.datePublished,
+    author: { "@type": "Person", name: cfg.author?.name, url: cfg.author?.url },
+    publisher: {
+      "@type": "Organization",
+      name: cfg.siteName || cfg.title,
+      logo: { "@type": "ImageObject", url: cfg.logo || cfg.siteImage },
+    },
+  };
+}
+
+/** Drop keys whose value is undefined/null (so optional fields vanish cleanly). */
+function prune(obj) {
+  if (Array.isArray(obj)) return obj.map(prune);
+  if (obj && typeof obj === "object") {
+    return Object.fromEntries(
+      Object.entries(obj)
+        .filter(([, v]) => v !== undefined && v !== null)
+        .map(([k, v]) => [k, prune(v)]),
+    );
+  }
+  return obj;
+}
+
+/**
+ * Render the full `<head>` SEO fragment as an HTML string. Description and image
+ * fall back through page → site. Returns build-time-injectable HTML.
+ */
+export function renderHead(cfg) {
+  const desc = cfg.description || cfg.siteDescription;
+  const image = cfg.image || cfg.siteImage;
+  const ogType = isArticle(cfg) ? "article" : "website";
+  const m = (l) => l.filter(Boolean).join("\n");
+
+  const tags = [
+    `<title>${esc(cfg.title)}${cfg.siteName ? ` | ${esc(cfg.siteName)}` : ""}</title>`,
+    `<meta name="viewport" content="width=device-width, initial-scale=1.0">`,
+    desc && `<meta name="description" content="${esc(desc)}">`,
+    cfg.author?.name && `<meta name="author" content="${esc(cfg.author.name)}">`,
+    cfg.keywords && `<meta name="keywords" content="${esc(cfg.keywords)}">`,
+    `<meta name="robots" content="index, follow">`,
+    cfg.url && `<link rel="canonical" href="${esc(cfg.url)}">`,
+    // Open Graph
+    `<meta property="og:title" content="${esc(cfg.title)}">`,
+    desc && `<meta property="og:description" content="${esc(desc)}">`,
+    cfg.url && `<meta property="og:url" content="${esc(cfg.url)}">`,
+    cfg.siteName && `<meta property="og:site_name" content="${esc(cfg.siteName)}">`,
+    `<meta property="og:type" content="${ogType}">`,
+    `<meta property="og:locale" content="${esc(cfg.locale || "en_US")}">`,
+    image && `<meta property="og:image" content="${esc(image)}">`,
+    // Twitter Card
+    `<meta name="twitter:card" content="${esc(cfg.twitterCard || "summary")}">`,
+    cfg.twitterUser && `<meta name="twitter:site" content="@${esc(cfg.twitterUser)}">`,
+    cfg.twitterUser && `<meta name="twitter:creator" content="@${esc(cfg.twitterUser)}">`,
+    `<meta name="twitter:title" content="${esc(cfg.title)}">`,
+    desc && `<meta name="twitter:description" content="${esc(desc)}">`,
+    image && `<meta name="twitter:image" content="${esc(image)}">`,
+    // JSON-LD (also feeds GEO/ASO)
+    `<script type="application/ld+json">${JSON.stringify(prune(buildJsonLd(cfg)))}</script>`,
+  ];
+  return m(tags) + "\n";
+}

--- a/brand/ui-kit/seo.js
+++ b/brand/ui-kit/seo.js
@@ -77,41 +77,50 @@ function prune(obj) {
   return obj;
 }
 
+/** A `<meta>` tag (name or property), or "" when the content is empty. */
+function metaTag(attr, key, content) {
+  return content ? `<meta ${attr}="${key}" content="${esc(content)}">` : "";
+}
+const metaName = (key, content) => metaTag("name", key, content);
+const metaProp = (key, content) => metaTag("property", key, content);
+
+/** JSON-LD `<script>` tag for the config (also feeds GEO/ASO). */
+function jsonLdTag(cfg) {
+  return `<script type="application/ld+json">${JSON.stringify(prune(buildJsonLd(cfg)))}</script>`;
+}
+
 /**
  * Render the full `<head>` SEO fragment as an HTML string. Description and image
- * fall back through page → site. Returns build-time-injectable HTML.
+ * fall back through page → site. Build-time-injectable; empty-valued tags drop.
  */
 export function renderHead(cfg) {
   const desc = cfg.description || cfg.siteDescription;
   const image = cfg.image || cfg.siteImage;
-  const ogType = isArticle(cfg) ? "article" : "website";
-  const m = (l) => l.filter(Boolean).join("\n");
+  const handle = cfg.twitterUser ? `@${esc(cfg.twitterUser)}` : "";
+  const titled = cfg.siteName ? `${esc(cfg.title)} | ${esc(cfg.siteName)}` : esc(cfg.title);
 
   const tags = [
-    `<title>${esc(cfg.title)}${cfg.siteName ? ` | ${esc(cfg.siteName)}` : ""}</title>`,
+    `<title>${titled}</title>`,
     `<meta name="viewport" content="width=device-width, initial-scale=1.0">`,
-    desc && `<meta name="description" content="${esc(desc)}">`,
-    cfg.author?.name && `<meta name="author" content="${esc(cfg.author.name)}">`,
-    cfg.keywords && `<meta name="keywords" content="${esc(cfg.keywords)}">`,
+    metaName("description", desc),
+    metaName("author", cfg.author?.name),
+    metaName("keywords", cfg.keywords),
     `<meta name="robots" content="index, follow">`,
-    cfg.url && `<link rel="canonical" href="${esc(cfg.url)}">`,
-    // Open Graph
-    `<meta property="og:title" content="${esc(cfg.title)}">`,
-    desc && `<meta property="og:description" content="${esc(desc)}">`,
-    cfg.url && `<meta property="og:url" content="${esc(cfg.url)}">`,
-    cfg.siteName && `<meta property="og:site_name" content="${esc(cfg.siteName)}">`,
-    `<meta property="og:type" content="${ogType}">`,
-    `<meta property="og:locale" content="${esc(cfg.locale || "en_US")}">`,
-    image && `<meta property="og:image" content="${esc(image)}">`,
-    // Twitter Card
-    `<meta name="twitter:card" content="${esc(cfg.twitterCard || "summary")}">`,
-    cfg.twitterUser && `<meta name="twitter:site" content="@${esc(cfg.twitterUser)}">`,
-    cfg.twitterUser && `<meta name="twitter:creator" content="@${esc(cfg.twitterUser)}">`,
-    `<meta name="twitter:title" content="${esc(cfg.title)}">`,
-    desc && `<meta name="twitter:description" content="${esc(desc)}">`,
-    image && `<meta name="twitter:image" content="${esc(image)}">`,
-    // JSON-LD (also feeds GEO/ASO)
-    `<script type="application/ld+json">${JSON.stringify(prune(buildJsonLd(cfg)))}</script>`,
+    cfg.url ? `<link rel="canonical" href="${esc(cfg.url)}">` : "",
+    metaProp("og:title", cfg.title),
+    metaProp("og:description", desc),
+    metaProp("og:url", cfg.url),
+    metaProp("og:site_name", cfg.siteName),
+    metaProp("og:type", isArticle(cfg) ? "article" : "website"),
+    metaProp("og:locale", cfg.locale || "en_US"),
+    metaProp("og:image", image),
+    metaName("twitter:card", cfg.twitterCard || "summary"),
+    metaName("twitter:site", handle),
+    metaName("twitter:creator", handle),
+    metaName("twitter:title", cfg.title),
+    metaName("twitter:description", desc),
+    metaName("twitter:image", image),
+    jsonLdTag(cfg),
   ];
-  return m(tags) + "\n";
+  return tags.filter(Boolean).join("\n") + "\n";
 }


### PR DESCRIPTION
## What

**E1** — a framework-free SEO head for the no-build / Vite GUIs, with parity to the Jekyll sites' `jekyll-seo-tag` output.

- `brand/ui-kit/seo.js` — `renderHead(cfg)` emits meta + Open Graph + Twitter Card + JSON-LD; `buildJsonLd(cfg)` switches `BlogPosting` (posts) vs `WebSite`+Person. Build-time helper (not a runtime injector).
- `brand/ui-kit/seo.html` — authored-template alternative with `{{PLACEHOLDERS}}`.
- README gains a **SEO** section; `DISCOVERABILITY.md` roadmap item marked done. JSON-LD also feeds GEO/ASO.

## Verify (no test suite, per discipline)

- `node --check seo.js` passes; `renderHead` output matches the captured qte77.github.io tag inventory; `buildJsonLd` validates as JSON for both `WebSite` and `BlogPosting` (with `dateModified` fallback + pruned optionals).
- HTML-attribute escaping via `esc()`.

Generated with Claude <noreply@anthropic.com>