### PR TITLE
fix(brand): escape inline JSON-LD in seo.js to prevent </script> breakout (XSS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brand/scripts/install_fonts.py`, `brand/README.md`, `brand/Makefile`: corrected the inaccurate "all fonts are SIL OFL 1.1" claim — the downloader pulls three license families (OFL 1.1, Ubuntu Font Licence 1.0 for Ubuntu Mono, Bitstream Vera + Arev for the canonical DejaVu bake font); docs now list every downloaded font with its actual license and point to `fonts/LICENSES/`
 - `brand/scripts/svg_text_to_paths.py`: honor `letter-spacing` attribute when shaping; previously paths SVGs spaced glyphs further apart than the canonical text SVG (PR #55)
 
+### Security
+
+- `brand/ui-kit/seo.js`: escape `<` `>` `&` (and U+2028/U+2029) in the inline JSON-LD `<script>` block, so a config value containing `</script>` can't break out of the script context — prevents XSS in the generated head HTML (PR #121)
+
 ## [0.3.0] - 2026-04-26
 
 ### Added

--- a/brand/ui-kit/seo.js
+++ b/brand/ui-kit/seo.js
@@ -84,9 +84,19 @@ function metaTag(attr, key, content) {
 const metaName = (key, content) => metaTag("name", key, content);
 const metaProp = (key, content) => metaTag("property", key, content);
 
-/** JSON-LD `<script>` tag for the config (also feeds GEO/ASO). */
+/**
+ * JSON-LD `<script>` tag for the config (also feeds GEO/ASO). Escapes `<` `>` `&`
+ * (and U+2028/U+2029) as `\uXXXX` so a value containing `</script>` can't break out
+ * of the script context — the result is still valid JSON that consumers decode back.
+ */
 function jsonLdTag(cfg) {
-  return `<script type="application/ld+json">${JSON.stringify(prune(buildJsonLd(cfg)))}</script>`;
+  const ld = JSON.stringify(prune(buildJsonLd(cfg)))
+    .replaceAll("<", "\\u003c")
+    .replaceAll(">", "\\u003e")
+    .replaceAll("&", "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+  return `<script type="application/ld+json">${ld}</script>`;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #120. `JSON.stringify` doesn't escape `<` `>` `&`, so a config value containing `</script>` would break out of the JSON-LD `<script>` context → **XSS** in the generated head HTML. Escapes them (and U+2028/U+2029) as `\uXXXX` — still valid JSON that consumers decode back.

Verified: a `</script><img>` payload in `description` renders as `\u003c/script\u003e…` (no breakout); `<`/`>`/`&` escaped; spaces intact. Caught by the automated commit security review.

Generated with Claude <noreply@anthropic.com>