### PR TITLE
docs(ui-kit): document behaviour/motion verification gotchas

### DIFF
--- a/brand/ui-kit/BASELINE.md
+++ b/brand/ui-kit/BASELINE.md
@@ -75,6 +75,12 @@ drift).
 
 Commands + the opt-in CI recipe live in [`README.md`](README.md) ("Verify with polyfetch").
 
+`gui-check.py` verifies **conformance** — the static contract (tokens, theme cycle, a11y,
+fonts, favicon, WebGL context). **Behaviour** verification — does a control actually *do*
+something over time (pause stops the idle motion, a toggle re-weights, a view snaps) — is the
+complementary, currently ad-hoc half, driven the same way but comparing **frames** (see the
+animation + Pillow gotchas below).
+
 ## Portable gotchas
 
 | Gotcha | Fix |
@@ -84,6 +90,8 @@ Commands + the opt-in CI recipe live in [`README.md`](README.md) ("Verify with p
 | headless WebGL blank | launch with `--enable-unsafe-swiftshader --ignore-gpu-blocklist` |
 | nested `sync_playwright()` throws | run polyfetch's `attempt()` outside your own context |
 | `fetch()` won't JS-render a 200 page | drive Patchright directly to execute JS |
+| idle animation (auto-rotate, transitions) confounds frame comparison | pause/disable it first, then compare; else every frame differs and the diff is meaningless |
+| frame-diffing screenshots needs Pillow (absent from polyfetch's env) | add `--with pillow` to the `uv run`; compare via `ImageChops`/`ImageStat` mean-diff |
 
 ## Actionable items
 


### PR DESCRIPTION
## What

Adds to `brand/ui-kit/BASELINE.md`:

- A note distinguishing **conformance** verification (what `gui-check.py` does — tokens, theme cycle, a11y, fonts, favicon, WebGL context) from **behaviour** verification (does a control actually *do* something over time), which is the complementary, currently ad-hoc half.
- Two **Portable gotchas** rows:
  - idle animation (auto-rotate, transitions) confounds frame comparison → pause/disable it first, else every frame differs.
  - frame-diffing screenshots needs Pillow (absent from polyfetch's env) → `uv run --with pillow`, compare via `ImageChops`/`ImageStat` mean-diff.

## Why

Surfaced while verifying paperverse's new cloud controls (pause / topic-time link toggle / axis snap) the `gui-check.py` way: the first link-toggle probe was confounded because auto-rotate made every frame differ (~0.14) regardless of the toggle; pausing first gave a clean signal (paused 0.0004 vs link change 0.076). The gotchas/Pillow note weren't written down anywhere.

Docs-only.

Generated with Claude <noreply@anthropic.com>