### PR TITLE
chore: repo hygiene — CHANGELOG union merge driver + CodeFactor learning

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Auto-resolve append-only CHANGELOG conflicts: when two branches both insert at the
+# top of the [Unreleased] section, keep BOTH sides instead of raising a merge conflict.
+# Fixes the recurring conflict that blocks concurrent docs PRs (e.g. #158).
+#
+# Scope: this repo's monolithic CHANGELOG.md only. Repos that use scriv / changelog.d
+# fragment files do NOT need this — separate fragments already avoid the conflict.
+# Note: guarantees clean local merges; GitHub's server-side merge normally honors the
+# built-in `union` driver too.
+CHANGELOG.md merge=union

--- a/AGENT_LEARNINGS.md
+++ b/AGENT_LEARNINGS.md
@@ -33,3 +33,10 @@ description: Non-obvious patterns that prevent repeated mistakes across sprints
 - **Problem**: (1) MD049 enforces emphasis-style *consistency within each file* — `docs/operating-model.md` is all-underscore, `docs/cto-handbook-mapping.md` is all-asterisk; mixing styles fails. (2) `set -e; markdownlint …` did **not** abort on a non-zero exit here (shipped a violating commit twice in one session).
 - **Solution**: Match the *target file's existing* emphasis char before editing. Gate explicitly — `if markdownlint "$f"; then …; else exit 1; fi` — never rely on `set -e` for the lint step.
 - **References**: PR #147.
+
+### Stuck `CodeFactor: ERROR` clears on a real update-to-main, not on nudge commits
+
+- **Context**: A required `CodeFactor` status check shows `ERROR` (often null description / empty target URL) and blocks a PR merge — common when a head SHA's analysis got stuck (seen on docs-only PRs).
+- **Problem**: Pushing empty "nudge CI" commits to force re-analysis does **not** clear it — the stuck SHA keeps its errored status — and it pollutes history. (Two nudge commits failed before the fix was found.)
+- **Solution**: Bring the branch **up to date with `main`** (`gh pr update-branch <n>`, or a local `git merge origin/main`). The fresh, GitHub-signed SHA gets a clean CodeFactor re-analysis that goes green. Never nudge-commit; never `--admin` past a genuinely failing/absent check (only the signature gate is bypassable).
+- **References**: PRs #158 / #159.


### PR DESCRIPTION
Two small hygiene items surfaced while merging this session's PR backlog.

**B1 — `.gitattributes`: `CHANGELOG.md merge=union`**
Auto-resolves the append-only `[Unreleased]` conflict that blocks concurrent docs PRs (hit on #158 this session). Scoped to this repo's monolithic `CHANGELOG.md`; repos using scriv / `changelog.d` fragments don't need it. Guarantees clean local merges; GitHub's server-side merge normally honors the built-in `union` driver too.

**B2 — `AGENT_LEARNINGS.md`: CodeFactor recovery**
A stuck `CodeFactor: ERROR` (null description) clears via a **real update-to-main** (fresh signed SHA is re-analyzed), never empty "nudge CI" commits (which failed twice before the fix was found on #158/#159).

**B3 — merge-queue decision (note only, no code):** `qte77/qte77` is ruleset-governed; a merge queue could auto-handle the strict up-to-date treadmill, but it's **deferred (YAGNI)** — B1 fixes the actual recurring pain, and the treadmill is only occasional at this repo's PR volume. Revisit if concurrent-PR batches become routine.

No CHANGELOG entry — contributor-facing only.

Generated with Claude <noreply@anthropic.com>